### PR TITLE
feat: integrate Variant management into TextileProduct module

### DIFF
--- a/src/andean/app/use_cases/textileProducts/CreateTextileProductUseCase.ts
+++ b/src/andean/app/use_cases/textileProducts/CreateTextileProductUseCase.ts
@@ -216,33 +216,6 @@ export class CreateTextileProductUseCase {
 					}
 				}
 			}
-
-			// Validar variants si existen
-			if (dto.variants && dto.variants.length > 0) {
-				for (const variant of dto.variants) {
-					// Validar que todas las keys en combination sean nombres de opciones válidos
-					const optionNamesSet = new Set(dto.options.map(opt => opt.name));
-					for (const combinationKey of Object.keys(variant.combination)) {
-						if (!optionNamesSet.has(combinationKey as TextileOptionName)) {
-							throw new BadRequestException(
-								`Invalid option name "${combinationKey}" in variant combination. Valid options are: ${Array.from(optionNamesSet).join(', ')}`,
-							);
-						}
-
-						// Validar que el value en combination sea un label válido de esa opción
-						const option = dto.options.find(opt => opt.name === combinationKey);
-						if (option) {
-							const validLabels = option.values.map(v => v.label);
-							const combinationValue = variant.combination[combinationKey];
-							if (!validLabels.includes(combinationValue)) {
-								throw new BadRequestException(
-									`Invalid label "${combinationValue}" for option "${combinationKey}". Valid labels are: ${validLabels.join(', ')}`,
-								);
-							}
-						}
-					}
-				}
-			}
 		}
 
 		const textileProductToSave = TextileProductMapper.fromCreateDto(dto);

--- a/src/andean/app/use_cases/textileProducts/GetByIdTextileProductDetailUseCase.ts
+++ b/src/andean/app/use_cases/textileProducts/GetByIdTextileProductDetailUseCase.ts
@@ -12,7 +12,9 @@ import { ColorOptionAlternativeRepository } from "../../datastore/textileProduct
 import { SizeOptionAlternativeRepository } from "../../datastore/textileProducts/SizeOptionAlternative.repo";
 import { TextileCategoryRepository } from "../../datastore/textileProducts/TextileCategory.repo";
 import { ShopRepository } from "../../datastore/Shop.repo";
+import { VariantRepository } from "../../datastore/Variant.repo";
 import { Review } from "src/andean/domain/entities/Review";
+import { Variant } from "src/andean/domain/entities/Variant";
 
 @Injectable()
 export class GetByIdTextileProductDetailUseCase {
@@ -35,6 +37,8 @@ export class GetByIdTextileProductDetailUseCase {
 		private readonly textileCategoryRepository: TextileCategoryRepository,
 		@Inject(ShopRepository)
 		private readonly shopRepository: ShopRepository,
+		@Inject(VariantRepository)
+		private readonly variantRepository: VariantRepository,
 	) {}
 
 	async handle(id: string): Promise<TextileProductDetailResponse> {
@@ -119,15 +123,18 @@ export class GetByIdTextileProductDetailUseCase {
 			}
 		}
 
-		// 10. Construir variantInfo
+		// 10. Obtener variants del producto
+		const variants = await this.variantRepository.getByProductId(product.id);
+
+		// 11. Construir variantInfo
 		const variantInfo = await this.buildVariantInfo(
-			product,
+			variants,
 			sizeOption,
 			colorOption,
 			materialOption,
 		);
 
-		// 11. Agrupar traceability epochs y agregar blockchainLink
+		// 12. Agrupar traceability epochs y agregar blockchainLink
 		const groupedEpochs = this.groupTraceabilityEpochs(
 			product.productTraceability?.epochs || [],
 		);
@@ -138,13 +145,13 @@ export class GetByIdTextileProductDetailUseCase {
 			...groupedEpochs,
 		};
 
-		// 12. Obtener productos similares
+		// 13. Obtener productos similares
 		const similarProducts = await this.getSimilarProducts(
 			product.id,
 			product.categoryId,
 		);
 
-		// 13. Obtener communityInfo si es COMMUNITY
+		// 14. Obtener communityInfo si es COMMUNITY
 		let communityInfo: {
 			bannerImageUrl: string;
 			name: string;
@@ -177,7 +184,7 @@ export class GetByIdTextileProductDetailUseCase {
 			}
 		}
 
-		// 14. Obtener category name
+		// 15. Obtener category name
 		let categoryName = '';
 		if (product.categoryId) {
 			const category = await this.textileCategoryRepository.getCategoryById(
@@ -186,7 +193,7 @@ export class GetByIdTextileProductDetailUseCase {
 			categoryName = category?.name || '';
 		}
 
-		// 15. Construir respuesta completa
+		// 16. Construir respuesta completa
 		return {
 			name: product.baseInfo.title,
 			availableSizes,
@@ -234,7 +241,7 @@ export class GetByIdTextileProductDetailUseCase {
 	}
 
 	private async buildVariantInfo(
-		product: any,
+		variants: Variant[],
 		sizeOption: any,
 		colorOption: any,
 		materialOption: any,
@@ -247,7 +254,7 @@ export class GetByIdTextileProductDetailUseCase {
 				stock: number;
 			}[]
 		> {
-		if (!product.variants || product.variants.length === 0) {
+		if (!variants || variants.length === 0) {
 			return [];
 		}
 
@@ -259,8 +266,8 @@ export class GetByIdTextileProductDetailUseCase {
 			stock: number;
 		}[] = [];
 
-		for (const variant of product.variants) {
-			// Obtener size del combination (ahora usa name directamente)
+		for (const variant of variants) {
+			// Obtener size del combination
 			let size = '';
 			if (sizeOption && variant.combination[TextileOptionName.SIZE]) {
 				const sizeLabel = variant.combination[TextileOptionName.SIZE];
@@ -277,7 +284,7 @@ export class GetByIdTextileProductDetailUseCase {
 				}
 			}
 
-			// Obtener color del combination (ahora usa name directamente)
+			// Obtener color del combination
 			let color = '';
 			if (colorOption && variant.combination[TextileOptionName.COLOR]) {
 				const colorLabel = variant.combination[TextileOptionName.COLOR];
@@ -294,7 +301,7 @@ export class GetByIdTextileProductDetailUseCase {
 				}
 			}
 
-			// Obtener material del combination (ahora usa name directamente)
+			// Obtener material del combination
 			let material = '';
 			if (materialOption && variant.combination[TextileOptionName.MATERIAL]) {
 				const materialLabel = variant.combination[TextileOptionName.MATERIAL];

--- a/src/andean/app/use_cases/textileProducts/UpdateTextileProductUseCase.ts
+++ b/src/andean/app/use_cases/textileProducts/UpdateTextileProductUseCase.ts
@@ -220,33 +220,6 @@ export class UpdateTextileProductUseCase {
 					}
 				}
 			}
-
-			// Validar variants si existen
-			if (dto.variants && dto.variants.length > 0) {
-				for (const variant of dto.variants) {
-					// Validar que todas las keys en combination sean nombres de opciones válidos
-					const optionNamesSet = new Set(dto.options.map(opt => opt.name));
-					for (const combinationKey of Object.keys(variant.combination)) {
-						if (!optionNamesSet.has(combinationKey as TextileOptionName)) {
-							throw new BadRequestException(
-								`Invalid option name "${combinationKey}" in variant combination. Valid options are: ${Array.from(optionNamesSet).join(', ')}`,
-							);
-						}
-
-						// Validar que el value en combination sea un label válido de esa opción
-						const option = dto.options.find(opt => opt.name === combinationKey);
-						if (option) {
-							const validLabels = option.values.map(v => v.label);
-							const combinationValue = variant.combination[combinationKey];
-							if (!validLabels.includes(combinationValue)) {
-								throw new BadRequestException(
-									`Invalid label "${combinationValue}" for option "${combinationKey}". Valid labels are: ${validLabels.join(', ')}`,
-								);
-							}
-						}
-					}
-				}
-			}
 		}
 
 		const toUpdate = TextileProductMapper.fromUpdateDto(id, dto);

--- a/src/andean/domain/entities/textileProducts/TextileProduct.ts
+++ b/src/andean/domain/entities/textileProducts/TextileProduct.ts
@@ -5,7 +5,6 @@ import { Atribute } from './Atribute';
 import { DetailTraceability } from './DetailTraceability';
 import { ProductTraceability } from '../ProductTraceability';
 import { TextileOptions } from './TextileOptions';
-import { TextileVariant } from './TextileVariant';
 
 export class TextileProduct {
 	constructor(
@@ -16,12 +15,12 @@ export class TextileProduct {
 		public priceInventary: PriceInventary,
 		public createdAt: Date,
 		public updatedAt: Date,
+		public isDiscountActive: boolean,
 
 		public categoryId?: string,
 		public atribute?: Atribute,
 		public detailTraceability?: DetailTraceability,
 		public productTraceability?: ProductTraceability,
 		public options?: TextileOptions[],
-		public variants?: TextileVariant[],
 	) {}
 }

--- a/src/andean/infra/controllers/dto/textileProducts/CreateTextileProductDto.ts
+++ b/src/andean/infra/controllers/dto/textileProducts/CreateTextileProductDto.ts
@@ -235,36 +235,6 @@ export class TextileOptionsDto {
 	values: TextileOptionsItemDto[];
 }
 
-export class TextileVariantDto {
-	@ApiProperty({
-		description: 'Combinación de opciones que define esta variante',
-		example: { color: 'rojo', size: 'M' },
-	})
-	@IsObject()
-	@IsNotEmpty()
-	combination: Record<string, string>;
-
-	@ApiProperty({
-		description: 'Precio específico de esta variante',
-		example: 165.00,
-		minimum: 0,
-	})
-	@IsNumber()
-	@Min(0)
-	@IsNotEmpty()
-	price: number;
-
-	@ApiProperty({
-		description: 'Stock disponible de esta variante',
-		example: 10,
-		minimum: 0,
-	})
-	@IsInt()
-	@Min(0)
-	@IsNotEmpty()
-	stock: number;
-}
-
 export class DetailTraceabilityDto {
 	@ApiPropertyOptional({
 		description: 'Indica si el producto es hecho a mano',
@@ -432,12 +402,11 @@ export class CreateTextileProductDto {
 	options?: TextileOptionsDto[];
 
 	@ApiPropertyOptional({
-		description: 'Variantes del producto con combinaciones específicas de opciones',
-		type: [TextileVariantDto],
+		description: 'Indica si el descuento está activo para este producto',
+		example: false,
+		default: false,
 	})
-	@IsArray()
+	@IsBoolean()
 	@IsOptional()
-	@ValidateNested({ each: true })
-	@Type(() => TextileVariantDto)
-	variants?: TextileVariantDto[];
+	isDiscountActive?: boolean;
 }

--- a/src/andean/infra/datastore/textileProducts/textileProduct.repo.impl.ts
+++ b/src/andean/infra/datastore/textileProducts/textileProduct.repo.impl.ts
@@ -3,6 +3,7 @@ import { TextileProductRepository } from '../../../app/datastore/textileProducts
 import { Model } from 'mongoose';
 import { InjectModel } from '@nestjs/mongoose';
 import { TextileProductDocument } from '../../persistence/textileProducts/textileProduct.schema';
+import { VariantDocument } from '../../persistence/variant.schema';
 import { TextileProduct } from 'src/andean/domain/entities/textileProducts/TextileProduct';
 import { TextileProductMapper } from '../../services/textileProducts/TextileProductMapper';
 import { MongoIdUtils } from '../../utils/MongoIdUtils';
@@ -14,12 +15,15 @@ export class TextileProductRepositoryImpl extends TextileProductRepository {
 	constructor(
 		@InjectModel('TextileProduct')
 		private readonly textileProductModel: Model<TextileProductDocument>,
+		@InjectModel('Variant')
+		private readonly variantModel: Model<VariantDocument>,
 	) {
 		super();
 	}
 
 	/**
-	 * Construye las condiciones de filtro de precio para variants y priceInventary
+	 * Construye las condiciones de filtro de precio para priceInventary
+	 * Note: Variants have been removed
 	 */
 	private buildPriceFilterConditions(minPrice?: number, maxPrice?: number): any[] {
 		const priceConditions: any[] = [];
@@ -39,22 +43,8 @@ export class TextileProductRepositoryImpl extends TextileProductRepository {
 			priceConditions.push(basePriceCondition);
 		}
 
-		// Condición para variants.price
-		const variantPriceElemMatch: any = {};
-		if (minPrice !== undefined) {
-			variantPriceElemMatch.price = { $gte: minPrice };
-		}
-		if (maxPrice !== undefined) {
-			variantPriceElemMatch.price = {
-				...variantPriceElemMatch.price,
-				$lte: maxPrice
-			};
-		}
-		if (Object.keys(variantPriceElemMatch).length > 0) {
-			priceConditions.push({
-				variants: { $elemMatch: variantPriceElemMatch }
-			});
-		}
+		// Variants have been removed, only use basePrice from priceInventary
+		// Price conditions are already handled above with priceInventary.basePrice
 
 		return priceConditions;
 	}
@@ -62,7 +52,7 @@ export class TextileProductRepositoryImpl extends TextileProductRepository {
 	/**
 	 * Construye el query base con filtros comunes (categoryId, ownerId, precio)
 	 */
-	private buildBaseQuery(filters?: any): any {
+	private async buildBaseQuery(filters?: any): Promise<any> {
 		const baseQuery: any = {};
 
 		if (filters?.categoryId) {
@@ -74,7 +64,7 @@ export class TextileProductRepositoryImpl extends TextileProductRepository {
 		}
 
 		if (filters?.minPrice !== undefined || filters?.maxPrice !== undefined) {
-			const priceConditions = this.buildPriceFilterConditions(filters.minPrice, filters.maxPrice);
+			const priceConditions = await this.buildPriceFilterConditions(filters.minPrice, filters.maxPrice);
 			if (priceConditions.length > 0) {
 				baseQuery.$or = priceConditions;
 			}
@@ -83,88 +73,118 @@ export class TextileProductRepositoryImpl extends TextileProductRepository {
 		return baseQuery;
 	}
 
-	/**
-	 * Construye expresión $ifNull encadenada para múltiples campos variantes
-	 */
-	private buildVariantFieldExpression(fieldNames: string[]): any {
-		if (fieldNames.length === 0) return null;
-		if (fieldNames.length === 1) return `$variants.combination.${fieldNames[0]}`;
-
-		return fieldNames.reduceRight<any>((acc, field, index) => {
-			const fieldPath = `$variants.combination.${field}`;
-			if (index === fieldNames.length - 1) {
-				return { $ifNull: [fieldPath, null] };
-			}
-			return { $ifNull: [fieldPath, acc] };
-		}, null);
-	}
 
 	/**
-	 * Ejecuta una aggregation para contar valores únicos de un campo variante
+	 * Ejecuta una aggregation para contar valores únicos de un campo variante desde la nueva entidad Variant
 	 */
-	private async aggregateVariantField(
+	private async aggregateVariantFieldForFilter(
 		baseQuery: any,
 		fieldNames: string[]
 	): Promise<Array<{ _id: string; count: number }>> {
-		const fieldExpression = this.buildVariantFieldExpression(fieldNames);
+		// Primero obtener los productIds que cumplen el baseQuery
+		const matchingProducts = await this.textileProductModel.find(baseQuery).exec();
+		const productIds = matchingProducts.map(p => p._id.toString());
 
-		return await this.textileProductModel.aggregate([
-			{ $match: baseQuery },
-			{ $unwind: '$variants' },
-			{
-				$group: {
-					_id: { $toLower: fieldExpression },
-					count: { $sum: 1 }
+		if (productIds.length === 0) {
+			return [];
+		}
+
+		// Buscar variants de esos productos
+		const variants = await this.variantModel.find({
+			productId: { $in: productIds }
+		}).exec();
+
+		// Contar valores únicos del campo en las combinaciones
+		const counts: Record<string, number> = {};
+		for (const variant of variants) {
+			for (const fieldName of fieldNames) {
+				const value = variant.combination[fieldName] || variant.combination[fieldName.toLowerCase()];
+				if (value) {
+					const key = value.toLowerCase();
+					counts[key] = (counts[key] || 0) + 1;
 				}
-			},
-			{ $match: { _id: { $ne: null } } },
-			{ $sort: { count: -1 } }
-		]);
+			}
+		}
+
+		// Convertir a formato de respuesta
+		return Object.entries(counts).map(([key, count]) => ({
+			_id: key,
+			count
+		}));
 	}
 
 	/**
-	 * Aplica filtros de color y size a un query base
+	 * Aplica filtros de color y size a un query base usando la nueva entidad Variant
 	 */
-	private applyVariantFilters(query: any, filters: any): void {
+	private async applyVariantFilters(query: any, filters: any): Promise<void> {
+		const productIdConditions: string[] = [];
+
 		// Filtro por color en variants
 		if (filters.color) {
-			query.variants = {
-				...query.variants,
-				$elemMatch: {
-					...((query.variants as any)?.$elemMatch || {}),
-					$or: [
-						{ 'combination.color': { $regex: new RegExp(filters.color, 'i') } },
-						{ 'combination.Color': { $regex: new RegExp(filters.color, 'i') } },
-					]
-				}
-			};
+			const colorVariants = await this.variantModel.find({
+				$or: [
+					{ 'combination.color': { $regex: new RegExp(filters.color, 'i') } },
+					{ 'combination.Color': { $regex: new RegExp(filters.color, 'i') } },
+				]
+			}).exec();
+			const colorProductIds = [...new Set(colorVariants.map(v => v.productId))];
+			if (colorProductIds.length > 0) {
+				productIdConditions.push(...colorProductIds);
+			} else {
+				// Si no hay variants con ese color, no hay productos que cumplan
+				productIdConditions.push(''); // Esto hará que no se encuentre nada
+			}
 		}
 
 		// Filtro por size en variants
 		if (filters.size) {
-			if (query.variants?.$elemMatch) {
-				query.variants.$elemMatch.$and = [
-					...(query.variants.$elemMatch.$and || []),
-					{
-						$or: [
-							{ 'combination.size': { $regex: new RegExp(filters.size, 'i') } },
-							{ 'combination.Size': { $regex: new RegExp(filters.size, 'i') } },
-							{ 'combination.talla': { $regex: new RegExp(filters.size, 'i') } },
-							{ 'combination.Talla': { $regex: new RegExp(filters.size, 'i') } },
-						]
-					}
-				];
+			const sizeVariants = await this.variantModel.find({
+				$or: [
+					{ 'combination.size': { $regex: new RegExp(filters.size, 'i') } },
+					{ 'combination.Size': { $regex: new RegExp(filters.size, 'i') } },
+					{ 'combination.talla': { $regex: new RegExp(filters.size, 'i') } },
+					{ 'combination.Talla': { $regex: new RegExp(filters.size, 'i') } },
+				]
+			}).exec();
+			const sizeProductIds = [...new Set(sizeVariants.map(v => v.productId))];
+			if (sizeProductIds.length > 0) {
+				if (productIdConditions.length > 0) {
+					// Si ya hay condiciones de color, hacer intersección
+					const intersection = productIdConditions.filter(id => sizeProductIds.includes(id));
+					productIdConditions.length = 0;
+					productIdConditions.push(...intersection);
+				} else {
+					productIdConditions.push(...sizeProductIds);
+				}
 			} else {
-				query.variants = {
-					$elemMatch: {
-						$or: [
-							{ 'combination.size': { $regex: new RegExp(filters.size, 'i') } },
-							{ 'combination.Size': { $regex: new RegExp(filters.size, 'i') } },
-							{ 'combination.talla': { $regex: new RegExp(filters.size, 'i') } },
-							{ 'combination.Talla': { $regex: new RegExp(filters.size, 'i') } },
-						]
+				// Si no hay variants con ese size, no hay productos que cumplan
+				productIdConditions.length = 0;
+				productIdConditions.push(''); // Esto hará que no se encuentre nada
+			}
+		}
+
+		// Si hay condiciones de productIds, agregarlas al query
+		if (productIdConditions.length > 0) {
+			// Filtrar IDs vacíos (que indican que no hay coincidencias)
+			const validProductIds = productIdConditions.filter(id => id !== '');
+			if (validProductIds.length > 0) {
+				// Convertir a ObjectIds y agregar al query
+				const objectIds = validProductIds.map(id => MongoIdUtils.stringToObjectId(id));
+				if (query._id) {
+					// Si ya hay condición de _id, hacer intersección
+					if (Array.isArray(query._id.$in)) {
+						query._id.$in = query._id.$in.filter((id: any) => 
+							objectIds.some(oid => oid.toString() === id.toString())
+						);
+					} else {
+						query._id = { $in: objectIds };
 					}
-				};
+				} else {
+					query._id = { $in: objectIds };
+				}
+			} else {
+				// No hay productos que cumplan los filtros
+				query._id = { $in: [] }; // Esto hará que no se encuentre nada
 			}
 		}
 	}
@@ -297,18 +317,7 @@ export class TextileProductRepositoryImpl extends TextileProductRepository {
 						''
 					]
 				},
-				price: {
-					$ifNull: [
-						{
-							$cond: {
-								if: { $gt: [{ $size: { $ifNull: ['$variants', []] } }, 0] },
-								then: { $min: '$variants.price' },
-								else: '$priceInventary.basePrice'
-							}
-						},
-						'$priceInventary.basePrice'
-					]
-				},
+				price: '$priceInventary.basePrice',
 				colors: {
 					$map: {
 						input: '$colorOptionIds',
@@ -339,36 +348,30 @@ export class TextileProductRepositoryImpl extends TextileProductRepository {
 				},
 				tallas: {
 					$reduce: {
-						input: { $ifNull: ['$variants', []] },
+						input: {
+							$let: {
+								vars: {
+									sizeOption: {
+										$arrayElemAt: [
+											{
+												$filter: {
+													input: { $ifNull: ['$options', []] },
+													as: 'opt',
+													cond: { $eq: ['$$opt.name', 'SIZE'] }
+												}
+											},
+											0
+										]
+									}
+								},
+								in: { $ifNull: ['$$sizeOption.values', []] }
+							}
+						},
 						initialValue: [],
 						in: {
 							$setUnion: [
 								'$$value',
-								{
-									$cond: [
-										{ $ifNull: ['$$this.combination.size', false] },
-										[{ $toLower: '$$this.combination.size' }],
-										{
-											$cond: [
-												{ $ifNull: ['$$this.combination.Size', false] },
-												[{ $toLower: '$$this.combination.Size' }],
-												{
-													$cond: [
-														{ $ifNull: ['$$this.combination.talla', false] },
-														[{ $toLower: '$$this.combination.talla' }],
-														{
-															$cond: [
-																{ $ifNull: ['$$this.combination.Talla', false] },
-																[{ $toLower: '$$this.combination.Talla' }],
-																[]
-															]
-														}
-													]
-												}
-											]
-										}
-									]
-								}
+								{ $ifNull: [{ $toLower: '$$this.label' }, []] }
 							]
 						}
 					}
@@ -480,16 +483,16 @@ export class TextileProductRepositoryImpl extends TextileProductRepository {
 	}
 
 	async getFilterCounts(filters?: any): Promise<FilterCount> {
-		const baseQuery = this.buildBaseQuery(filters);
+		const baseQuery = await this.buildBaseQuery(filters);
 
-		// Aggregation para contar colores
-		const colorAggregation = await this.aggregateVariantField(
+		// Aggregation para contar colores desde variants
+		const colorAggregation = await this.aggregateVariantFieldForFilter(
 			baseQuery,
 			['color', 'Color']
 		);
 
-		// Aggregation para contar tallas/sizes
-		const sizeAggregation = await this.aggregateVariantField(
+		// Aggregation para contar tallas/sizes desde variants
+		const sizeAggregation = await this.aggregateVariantFieldForFilter(
 			baseQuery,
 			['size', 'Size', 'talla', 'Talla']
 		);
@@ -533,10 +536,10 @@ export class TextileProductRepositoryImpl extends TextileProductRepository {
 	}
 
 	async getAllWithFilters(filters: any): Promise<{ products: TextileProductListItem[]; total: number }> {
-		const query = this.buildBaseQuery(filters);
+		const query = await this.buildBaseQuery(filters);
 
 		// Aplicar filtros de variantes usando método modular
-		this.applyVariantFilters(query, filters);
+		await this.applyVariantFilters(query, filters);
 
 		// Paginación
 		const page = filters.page || 1;

--- a/src/andean/infra/persistence/textileProducts/textileProduct.schema.ts
+++ b/src/andean/infra/persistence/textileProducts/textileProduct.schema.ts
@@ -75,15 +75,6 @@ const TextileOptionsSchema = new Schema(
 	{ _id: false },
 );
 
-const TextileVariantSchema = new Schema(
-	{
-		combination: { type: Schema.Types.Mixed, required: true },
-		price: { type: Number, required: true },
-		stock: { type: Number, required: true },
-	},
-	{ _id: false },
-);
-
 const DetailTraceabilitySchema = new Schema(
 	{
 		isHandmade: { type: Boolean, required: false },
@@ -138,7 +129,7 @@ export const TextileProductSchema = new Schema({
 	detailTraceability: { type: DetailTraceabilitySchema, required: false },
 	productTraceability: { type: ProductTraceabilitySchema, required: false },
 	options: { type: [TextileOptionsSchema], default: [], required: false },
-	variants: { type: [TextileVariantSchema], default: [], required: false },
+	isDiscountActive: { type: Boolean, default: false, required: true },
 	createdAt: { type: Date, default: Date.now },
 	updatedAt: { type: Date, default: Date.now },
 });
@@ -186,7 +177,7 @@ export interface TextileProductDocument extends Document {
 	};
 	productTraceability?: any;
 	options?: any[];
-	variants?: any[];
+	isDiscountActive: boolean;
 	createdAt: Date;
 	updatedAt: Date;
 }

--- a/src/andean/infra/services/textileProducts/TextileProductMapper.ts
+++ b/src/andean/infra/services/textileProducts/TextileProductMapper.ts
@@ -9,7 +9,6 @@ import { PreparationTime } from 'src/andean/domain/entities/textileProducts/Prep
 import { DetailTraceability } from 'src/andean/domain/entities/textileProducts/DetailTraceability';
 import { TextileOptions } from 'src/andean/domain/entities/textileProducts/TextileOptions';
 import { TextileOptionsItem } from 'src/andean/domain/entities/textileProducts/TextileOptionsItem';
-import { TextileVariant } from 'src/andean/domain/entities/textileProducts/TextileVariant';
 import { ProductTraceability } from 'src/andean/domain/entities/ProductTraceability';
 import { Types } from 'mongoose';
 
@@ -61,10 +60,6 @@ export class TextileProductMapper {
 			return plainToInstance(TextileOptions, { ...opt, values });
 		});
 
-		const variants = plain.variants?.map((variant: any) =>
-			plainToInstance(TextileVariant, variant),
-		);
-
 		return plainToInstance(TextileProduct, {
 			id: plain._id.toString(),
 			...plain,
@@ -74,7 +69,7 @@ export class TextileProductMapper {
 			detailTraceability,
 			productTraceability,
 			options,
-			variants,
+			isDiscountActive: plain.isDiscountActive ?? false,
 			createdAt: plain.createdAt || new Date(),
 			updatedAt: plain.updatedAt || new Date(),
 		});
@@ -123,10 +118,6 @@ export class TextileProductMapper {
 			});
 		});
 
-		const variants = (dto.variants || []).map((variant) =>
-			plainToInstance(TextileVariant, variant),
-		);
-
 		const plain = {
 			id: new Types.ObjectId().toString(),
 			...textileProductData,
@@ -136,7 +127,7 @@ export class TextileProductMapper {
 			detailTraceability,
 			productTraceability,
 			options,
-			variants,
+			isDiscountActive: dto.isDiscountActive ?? false,
 			createdAt: new Date(),
 			updatedAt: new Date(),
 		};
@@ -193,10 +184,6 @@ export class TextileProductMapper {
 			});
 		});
 
-		const variants = dto.variants?.map((variant) =>
-			plainToInstance(TextileVariant, variant),
-		);
-
 		const plain = {
 			id: id,
 			...textileProductData,
@@ -206,7 +193,7 @@ export class TextileProductMapper {
 			detailTraceability,
 			productTraceability,
 			options,
-			variants,
+			isDiscountActive: dto.isDiscountActive ?? false,
 			updatedAt: new Date(),
 			// createdAt no se incluye aquí, se preserva del documento original
 		};
@@ -216,7 +203,7 @@ export class TextileProductMapper {
 
 	static toPersistence(textileProduct: TextileProduct) {
 		const plain = instanceToPlain(textileProduct);
-		const { id, ...updateData } = plain;
+		const { id, _id, __v, ...updateData } = plain;
 
 		return {
 			...updateData,

--- a/src/andean/textileProduct.module.ts
+++ b/src/andean/textileProduct.module.ts
@@ -116,6 +116,8 @@ import { IncrementDislikesUseCase } from './app/use_cases/IncrementDislikesUseCa
 import { DecrementLikesUseCase } from './app/use_cases/DecrementLikesUseCase';
 import { DecrementDislikesUseCase } from './app/use_cases/DecrementDislikesUseCase';
 import { SuperfoodModule } from './superfood.module';
+import { VariantModule } from './variant.module';
+import { VariantSchema } from './infra/persistence/variant.schema';
 
 @Module({
 	imports: [
@@ -168,11 +170,16 @@ import { SuperfoodModule } from './superfood.module';
 				name: 'Review',
 				schema: ReviewSchema,
 			},
+			{
+				name: 'Variant',
+				schema: VariantSchema,
+			},
 		]),
 		UsersModule,
 		ShopsModule,
 		CommunityModule,
 		OriginProductModule,
+		VariantModule,
 		forwardRef(() => SuperfoodModule),
 	],
 	controllers: [


### PR DESCRIPTION
- Added VariantModule and VariantSchema to the TextileProduct module for better variant handling.
- Removed variant validation logic from CreateTextileProductUseCase and UpdateTextileProductUseCase.
- Updated GetByIdTextileProductDetailUseCase to fetch variants directly from the VariantRepository.
- Adjusted TextileProduct schema to remove variants field and include isDiscountActive.
- Refactored TextileProductMapper to accommodate changes in variant handling and mapping.