### PR TITLE
feat: add images to textile product detail response

### DIFF
--- a/src/andean/app/models/TextileProducts/TextileProductDetailResponse.ts
+++ b/src/andean/app/models/TextileProducts/TextileProductDetailResponse.ts
@@ -1,88 +1,264 @@
-export class TextileProductDetailResponse {
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { MediaItemRole } from 'src/andean/domain/enums/MediaItemRole';
+
+// ── Media ────────────────────────────────────────────────────────────────
+export class MediaImageResponse {
+	@ApiProperty({
+		description: 'Nombre del archivo',
+		example: 'textile-principal.jpg',
+	})
 	name!: string;
-	availableSizes!: string[];
-	availableColors!: string[];
-	availableMaterials!: string[];
-	variantInfo!: {
-		size: string;
-		color: string;
-		material: string;
-		price: number;
-		stock: number;
-	}[];
-	generalStock!: number;
-	information!: string;
+
+	@ApiProperty({ enum: MediaItemRole, description: 'Rol del media item' })
+	role!: MediaItemRole;
+
+	@ApiProperty({
+		description: 'URL de la imagen',
+		example: 'https://cdn.example.com/textile.jpg',
+	})
+	url!: string;
+}
+
+// ── Variant Info ──────────────────────────────────────────────────────────
+export class VariantInfoResponse {
+	@ApiProperty({ description: 'Talla de la variante', example: 'M' })
+	size!: string;
+
+	@ApiProperty({ description: 'Color de la variante', example: 'Rojo' })
+	color!: string;
+
+	@ApiProperty({ description: 'Material de la variante', example: 'Algodón' })
+	material!: string;
+
+	@ApiProperty({ description: 'Precio de la variante', example: 150.0 })
+	price!: number;
+
+	@ApiProperty({ description: 'Stock disponible de la variante', example: 25 })
+	stock!: number;
+}
+
+// ── Traceability Step ──────────────────────────────────────────────────────
+export class TraceabilityStep {
+	@ApiProperty({ description: 'Título del paso de trazabilidad' })
+	title!: string;
+
+	@ApiProperty({ description: 'Proveedor del paso' })
+	supplier!: string;
+
+	@ApiProperty({ description: 'País del paso' })
+	country!: string;
+
+	@ApiProperty({ description: 'Ciudad del paso' })
+	city!: string;
+
+	@ApiProperty({ description: 'Descripción del paso' })
 	description!: string;
-	traceabilityInfo!: {
-		blockchainLink?: string;
-		origen: {
-			title: string;
-			supplier: string;
-			country: string;
-			city: string;
-			description: string;
-		}[];
-		processing: {
-			title: string;
-			supplier: string;
-			country: string;
-			city: string;
-			description: string;
-		}[];
-		development: {
-			title: string;
-			supplier: string;
-			country: string;
-			city: string;
-			description: string;
-		}[];
-		merchandising: {
-			title: string;
-			supplier: string;
-			country: string;
-			city: string;
-			description: string;
-		}[];
-	};
-	reviews!: {
-		rating: {
-			count5stars: number;
-			count4stars: number;
-			count3stars: number;
-			count2stars: number;
-			count1star: number;
-			totalReviews: number;
-			averagePunctuation: number;
-		};
-		comments: {
-			idReview: string;
-			nameUser: string;
-			content: string;
-			numberStarts: number;
-			date: Date;
-			likes: number;
-			dislikes: number;
-		}[];
-	};
-	similarProducts!: {
-		title: string;
-		categoryName: string;
-		productorName: string;
-		colors: {
-			colorName: string;
-			colorHexCode: string;
-		}[];
-		sizes: string[];
-		principalImgUrl: string;
-		price: number;
-	}[];
-	communityInfo?: {
-		bannerImageId: string;
-		name: string;
-		seals: {
-			title: string;
-			description: string;
-			logoMediaId: string;
-		}[];
-	};
+}
+
+export class TraceabilityInfoResponse {
+	@ApiPropertyOptional({ description: 'Enlace a blockchain para trazabilidad' })
+	blockchainLink?: string;
+
+	@ApiProperty({
+		type: [TraceabilityStep],
+		description: 'Pasos de origen del producto',
+	})
+	origen!: TraceabilityStep[];
+
+	@ApiProperty({
+		type: [TraceabilityStep],
+		description: 'Pasos de procesamiento',
+	})
+	processing!: TraceabilityStep[];
+
+	@ApiProperty({ type: [TraceabilityStep], description: 'Pasos de desarrollo' })
+	development!: TraceabilityStep[];
+
+	@ApiProperty({
+		type: [TraceabilityStep],
+		description: 'Pasos de merchandising',
+	})
+	merchandising!: TraceabilityStep[];
+}
+
+// ── Review ────────────────────────────────────────────────────────────────
+export class ReviewRatingResponse {
+	@ApiProperty({ description: 'Cantidad de reseñas con 5 estrellas' })
+	count5stars!: number;
+
+	@ApiProperty({ description: 'Cantidad de reseñas con 4 estrellas' })
+	count4stars!: number;
+
+	@ApiProperty({ description: 'Cantidad de reseñas con 3 estrellas' })
+	count3stars!: number;
+
+	@ApiProperty({ description: 'Cantidad de reseñas con 2 estrellas' })
+	count2stars!: number;
+
+	@ApiProperty({ description: 'Cantidad de reseñas con 1 estrella' })
+	count1star!: number;
+
+	@ApiProperty({ description: 'Total de reseñas' })
+	totalReviews!: number;
+
+	@ApiProperty({ description: 'Puntuación promedio' })
+	averagePunctuation!: number;
+}
+
+export class ReviewCommentResponse {
+	@ApiProperty({ description: 'ID de la reseña' })
+	idReview!: string;
+
+	@ApiProperty({ description: 'Nombre del usuario que hizo la reseña' })
+	nameUser!: string;
+
+	@ApiProperty({ description: 'Contenido de la reseña' })
+	content!: string;
+
+	@ApiProperty({ description: 'Número de estrellas de la reseña' })
+	numberStarts!: number;
+
+	@ApiProperty({ description: 'Fecha de la reseña' })
+	date!: Date;
+
+	@ApiProperty({ description: 'Cantidad de likes' })
+	likes!: number;
+
+	@ApiProperty({ description: 'Cantidad de dislikes' })
+	dislikes!: number;
+}
+
+export class ReviewsResponse {
+	@ApiProperty({
+		type: ReviewRatingResponse,
+		description: 'Información de calificaciones',
+	})
+	rating!: ReviewRatingResponse;
+
+	@ApiProperty({
+		type: [ReviewCommentResponse],
+		description: 'Comentarios de las reseñas',
+	})
+	comments!: ReviewCommentResponse[];
+}
+
+// ── Similar Product ───────────────────────────────────────────────────────
+export class ColorInfoResponse {
+	@ApiProperty({ description: 'Nombre del color', example: 'Rojo' })
+	colorName!: string;
+
+	@ApiProperty({
+		description: 'Código hexadecimal del color',
+		example: '#FF0000',
+	})
+	colorHexCode!: string;
+}
+
+export class SimilarProductResponse {
+	@ApiProperty({ description: 'Título del producto similar' })
+	title!: string;
+
+	@ApiProperty({ description: 'Nombre de la categoría' })
+	categoryName!: string;
+
+	@ApiProperty({ description: 'Nombre del productor' })
+	productorName!: string;
+
+	@ApiProperty({
+		type: [ColorInfoResponse],
+		description: 'Colores disponibles',
+	})
+	colors!: ColorInfoResponse[];
+
+	@ApiProperty({ type: [String], description: 'Tallas disponibles' })
+	sizes!: string[];
+
+	@ApiProperty({ description: 'URL de la imagen principal' })
+	principalImgUrl!: string;
+
+	@ApiProperty({ description: 'Precio del producto' })
+	price!: number;
+}
+
+// ── Community Info ────────────────────────────────────────────────────────
+export class SealInfoResponse {
+	@ApiProperty({ description: 'Título del sello' })
+	title!: string;
+
+	@ApiProperty({ description: 'Descripción del sello' })
+	description!: string;
+
+	@ApiProperty({ description: 'ID del media del logo del sello' })
+	logoMediaId!: string;
+}
+
+export class CommunityInfoResponse {
+	@ApiProperty({ description: 'ID de la imagen del banner de la comunidad' })
+	bannerImageId!: string;
+
+	@ApiProperty({ description: 'Nombre de la comunidad' })
+	name!: string;
+
+	@ApiProperty({
+		type: [SealInfoResponse],
+		description: 'Sellos de la comunidad',
+	})
+	seals!: SealInfoResponse[];
+}
+
+// ── Main response ────────────────────────────────────────────────────────
+export class TextileProductDetailResponse {
+	@ApiProperty({ description: 'Nombre del producto textil' })
+	name!: string;
+
+	@ApiProperty({
+		type: [MediaImageResponse],
+		description: 'Imágenes del producto',
+	})
+	images!: MediaImageResponse[];
+
+	@ApiProperty({ type: [String], description: 'Tallas disponibles' })
+	availableSizes!: string[];
+
+	@ApiProperty({ type: [String], description: 'Colores disponibles' })
+	availableColors!: string[];
+
+	@ApiProperty({ type: [String], description: 'Materiales disponibles' })
+	availableMaterials!: string[];
+
+	@ApiProperty({
+		type: [VariantInfoResponse],
+		description: 'Información de variantes disponibles',
+	})
+	variantInfo!: VariantInfoResponse[];
+
+	@ApiProperty({ description: 'Stock general del producto' })
+	generalStock!: number;
+
+	@ApiProperty({ description: 'Información del producto' })
+	information!: string;
+
+	@ApiProperty({ description: 'Descripción del producto' })
+	description!: string;
+
+	@ApiProperty({
+		type: TraceabilityInfoResponse,
+		description: 'Información de trazabilidad',
+	})
+	traceabilityInfo!: TraceabilityInfoResponse;
+
+	@ApiProperty({ type: ReviewsResponse, description: 'Reseñas del producto' })
+	reviews!: ReviewsResponse;
+
+	@ApiProperty({
+		type: [SimilarProductResponse],
+		description: 'Productos similares',
+	})
+	similarProducts!: SimilarProductResponse[];
+
+	@ApiPropertyOptional({
+		type: CommunityInfoResponse,
+		description: 'Información de la comunidad asociada',
+	})
+	communityInfo?: CommunityInfoResponse;
 }

--- a/src/andean/app/models/superfoods/SuperfoodProductDetailResponse.ts
+++ b/src/andean/app/models/superfoods/SuperfoodProductDetailResponse.ts
@@ -2,10 +2,16 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 // ── Media ────────────────────────────────────────────────────────────────
 export class MediaImageResponse {
-	@ApiProperty({ description: 'Nombre del archivo', example: 'quinua-principal.jpg' })
+	@ApiProperty({
+		description: 'Nombre del archivo',
+		example: 'quinua-principal.jpg',
+	})
 	name!: string;
 
-	@ApiProperty({ description: 'URL de la imagen', example: 'https://cdn.example.com/quinua.jpg' })
+	@ApiProperty({
+		description: 'URL de la imagen',
+		example: 'https://cdn.example.com/quinua.jpg',
+	})
 	url!: string;
 }
 
@@ -37,11 +43,13 @@ export class TraceabilityInfoResponse {
 export class HeroDetailResponse {
 	@ApiProperty() title!: string;
 	@ApiProperty() description!: string;
-	@ApiProperty({ type: [NutritionalFeatureInfo] }) nutritionalFeatures!: NutritionalFeatureInfo[];
+	@ApiProperty({ type: [NutritionalFeatureInfo] })
+	nutritionalFeatures!: NutritionalFeatureInfo[];
 	@ApiProperty() basePrice!: number;
 	@ApiProperty() totalStock!: number;
 	@ApiProperty() isDiscountActive!: boolean;
-	@ApiProperty({ type: TraceabilityInfoResponse }) traceabilityInfo!: TraceabilityInfoResponse;
+	@ApiProperty({ type: TraceabilityInfoResponse })
+	traceabilityInfo!: TraceabilityInfoResponse;
 }
 
 // ── Owner ────────────────────────────────────────────────────────────────
@@ -105,7 +113,8 @@ export class ReviewCommentResponse {
 
 export class ReviewsResponse {
 	@ApiProperty({ type: ReviewRatingResponse }) rating!: ReviewRatingResponse;
-	@ApiProperty({ type: [ReviewCommentResponse] }) comments!: ReviewCommentResponse[];
+	@ApiProperty({ type: [ReviewCommentResponse] })
+	comments!: ReviewCommentResponse[];
 }
 
 // ── Main response ────────────────────────────────────────────────────────
@@ -114,18 +123,24 @@ export class SuperfoodProductDetailResponse {
 
 	@ApiProperty({ type: MediaImageResponse }) mainImg!: MediaImageResponse;
 	@ApiProperty({ type: MediaImageResponse }) plateImg!: MediaImageResponse;
-	@ApiProperty({ type: MediaImageResponse }) sourceProductImg!: MediaImageResponse;
+	@ApiProperty({ type: MediaImageResponse })
+	sourceProductImg!: MediaImageResponse;
 
 	@ApiProperty({ type: HeroDetailResponse }) heroDetail!: HeroDetailResponse;
 	@ApiProperty({ type: OwnerInfoResponse }) owner!: OwnerInfoResponse;
 
-	@ApiProperty({ type: [BenefitInfoResponse] }) benefitsInfo!: BenefitInfoResponse[];
-	@ApiProperty({ type: SourceProductInfoResponse }) sourceProductInfo!: SourceProductInfoResponse;
+	@ApiProperty({ type: [BenefitInfoResponse] })
+	benefitsInfo!: BenefitInfoResponse[];
+	@ApiProperty({ type: SourceProductInfoResponse })
+	sourceProductInfo!: SourceProductInfoResponse;
 
-	@ApiProperty({ type: [StrikingNutritionalItemResponse] }) strikingNutritionalItems!: StrikingNutritionalItemResponse[];
-	@ApiProperty({ type: [NutritionalItemResponse] }) nutritionalInformation!: NutritionalItemResponse[];
+	@ApiProperty({ type: [StrikingNutritionalItemResponse] })
+	strikingNutritionalItems!: StrikingNutritionalItemResponse[];
+	@ApiProperty({ type: [NutritionalItemResponse] })
+	nutritionalInformation!: NutritionalItemResponse[];
 
-	@ApiProperty({ description: 'Productos similares (máximo 6)' }) moreProducts!: SuperfoodProductListItemCompact[];
+	@ApiProperty({ description: 'Productos similares (máximo 6)' })
+	moreProducts!: SuperfoodProductListItemCompact[];
 	@ApiProperty({ type: ReviewsResponse }) reviews!: ReviewsResponse;
 }
 
@@ -138,6 +153,7 @@ export class SuperfoodProductListItemCompact {
 	@ApiProperty() price!: number;
 	@ApiProperty() totalStock!: number;
 	@ApiProperty({ type: MediaImageResponse }) mainImage!: MediaImageResponse;
-	@ApiProperty({ type: MediaImageResponse }) sourceProductImage!: MediaImageResponse;
+	@ApiProperty({ type: MediaImageResponse })
+	sourceProductImage!: MediaImageResponse;
 	@ApiProperty({ type: [String] }) nutritionItems!: string[];
 }

--- a/src/andean/app/use_cases/superfoods/GetByIdSuperfoodProductDetailUseCase.ts
+++ b/src/andean/app/use_cases/superfoods/GetByIdSuperfoodProductDetailUseCase.ts
@@ -46,16 +46,14 @@ export class GetByIdSuperfoodProductDetailUseCase {
 		private readonly mediaItemRepository: MediaItemRepository,
 		@Inject(DetailSourceProductRepository)
 		private readonly detailSourceProductRepository: DetailSourceProductRepository,
-	) { }
+	) {}
 
 	async handle(productId: string): Promise<SuperfoodProductDetailResponse> {
 		// 1. Obtener producto principal
 		const product =
 			await this.superfoodProductRepository.getSuperfoodProductById(productId);
 		if (!product) {
-			throw new NotFoundException(
-				`Producto con ID ${productId} no encontrado`,
-			);
+			throw new NotFoundException(`Producto con ID ${productId} no encontrado`);
 		}
 
 		// 2. Lanzar consultas independientes en paralelo para mejor rendimiento
@@ -74,8 +72,8 @@ export class GetByIdSuperfoodProductDetailUseCase {
 				),
 				product.detailSourceProductId
 					? this.detailSourceProductRepository.getById(
-						product.detailSourceProductId,
-					)
+							product.detailSourceProductId,
+						)
 					: Promise.resolve(null),
 			]);
 
@@ -145,10 +143,10 @@ export class GetByIdSuperfoodProductDetailUseCase {
 		// 11. Source product info
 		const sourceProductInfo = sourceProduct
 			? {
-				name: sourceProduct.name,
-				description: sourceProduct.description,
-				features: sourceProduct.features,
-			}
+					name: sourceProduct.name,
+					description: sourceProduct.description,
+					features: sourceProduct.features,
+				}
 			: { name: '', description: '', features: [] };
 
 		// 12. Construir respuesta

--- a/src/andean/app/use_cases/textileProducts/GetByIdTextileProductDetailUseCase.ts
+++ b/src/andean/app/use_cases/textileProducts/GetByIdTextileProductDetailUseCase.ts
@@ -16,6 +16,7 @@ import { VariantRepository } from '../../datastore/Variant.repo';
 import { AccountRepository } from '../../datastore/Account.repo';
 import { Review } from 'src/andean/domain/entities/Review';
 import { Variant } from 'src/andean/domain/entities/Variant';
+import { MediaItemRepository } from '../../datastore/MediaItem.repo';
 
 @Injectable()
 export class GetByIdTextileProductDetailUseCase {
@@ -42,37 +43,51 @@ export class GetByIdTextileProductDetailUseCase {
 		private readonly variantRepository: VariantRepository,
 		@Inject(AccountRepository)
 		private readonly accountRepository: AccountRepository,
-	) { }
+		@Inject(MediaItemRepository)
+		private readonly mediaItemRepository: MediaItemRepository,
+	) {}
 
 	async handle(id: string): Promise<TextileProductDetailResponse> {
-		// 1. Obtener el producto principal
+		// -- Obtener el producto principal
 		const product =
 			await this.textileProductRepository.getTextileProductById(id);
 		if (!product) {
 			throw new NotFoundException('Textile product not found');
 		}
 
-		// 2. Obtener reviews del producto
+		// -- Obtener media items del producto
+		const mediaItems = await this.mediaItemRepository.getByIds(
+			product.baseInfo.mediaIds || [],
+		);
+		const images = mediaItems.map((mediaItem) => ({
+			name: mediaItem.name,
+			role: mediaItem.role,
+			url: `${process.env.AWS_S3_BASE_URL}/${mediaItem.key}`, // TODO: Usar el storage base url
+		}));
+
+		// -- Obtener reviews del producto
 		const reviews = await this.reviewRepository.getByProductIdAndType(
 			id,
 			ProductType.TEXTILE,
 		);
 
-		// 3. Obtener customers para las reviews y sus nombres de Account
+		// -- Obtener customers para las reviews y sus nombres de Account
 		const customerPromises = reviews.map((review) =>
 			this.customerProfileRepository.getCustomerById(review.customerId),
 		);
 		const customers = await Promise.all(customerPromises);
 
 		const accountPromises = customers.map((customer) =>
-			customer ? this.accountRepository.getAccountByUserId(customer.userId) : Promise.resolve(null),
+			customer
+				? this.accountRepository.getAccountByUserId(customer.userId)
+				: Promise.resolve(null),
 		);
 		const accounts = await Promise.all(accountPromises);
 
-		// 4. Calcular estadísticas de ratings
+		// -- Calcular estadísticas de ratings
 		const ratingStats = this.calculateRatingStats(reviews);
 
-		// 5. Mapear comments de reviews
+		// -- Mapear comments de reviews
 		const comments = reviews.map((review, index) => ({
 			idReview: review.id,
 			nameUser: accounts[index]?.name || 'Usuario Anónimo',
@@ -83,7 +98,7 @@ export class GetByIdTextileProductDetailUseCase {
 			dislikes: review.numberDislikes,
 		}));
 
-		// 6. Obtener sizes y colors de options
+		// -- Obtener sizes y colors de options
 		const sizeOption = product.options?.find(
 			(opt) => opt.name === TextileOptionName.SIZE,
 		);
@@ -94,7 +109,7 @@ export class GetByIdTextileProductDetailUseCase {
 			(opt) => opt.name === TextileOptionName.MATERIAL,
 		);
 
-		// 7. Obtener availableSizes
+		// -- Obtener availableSizes
 		const availableSizes: string[] = [];
 		if (sizeOption) {
 			for (const value of sizeOption.values) {
@@ -111,7 +126,7 @@ export class GetByIdTextileProductDetailUseCase {
 			}
 		}
 
-		// 8. Obtener availableColors
+		// -- Obtener availableColors
 		const availableColors: string[] = [];
 		if (colorOption) {
 			for (const value of colorOption.values) {
@@ -128,7 +143,7 @@ export class GetByIdTextileProductDetailUseCase {
 			}
 		}
 
-		// 9. Obtener availableMaterials
+		// -- Obtener availableMaterials
 		const availableMaterials: string[] = [];
 		if (materialOption) {
 			for (const value of materialOption.values) {
@@ -138,10 +153,10 @@ export class GetByIdTextileProductDetailUseCase {
 			}
 		}
 
-		// 10. Obtener variants del producto
+		// -- Obtener variants del producto
 		const variants = await this.variantRepository.getByProductId(product.id);
 
-		// 11. Construir variantInfo
+		// -- Construir variantInfo
 		const variantInfo = await this.buildVariantInfo(
 			variants,
 			sizeOption,
@@ -149,7 +164,7 @@ export class GetByIdTextileProductDetailUseCase {
 			materialOption,
 		);
 
-		// 12. Agrupar traceability epochs y agregar blockchainLink
+		// -- Agrupar traceability epochs y agregar blockchainLink
 		const groupedEpochs = this.groupTraceabilityEpochs(
 			product.productTraceability?.epochs || [],
 		);
@@ -160,19 +175,19 @@ export class GetByIdTextileProductDetailUseCase {
 			...groupedEpochs,
 		};
 
-		// 13. Obtener productos similares
+		// -- Obtener productos similares
 		const similarProducts = await this.getSimilarProducts(
 			product.id,
 			product.categoryId,
 		);
 
-		// 14. Obtener communityInfo si es COMMUNITY
+		// -- Obtener communityInfo si es COMMUNITY
 		let communityInfo:
 			| {
-				bannerImageId: string;
-				name: string;
-				seals: { title: string; description: string; logoMediaId: string }[];
-			}
+					bannerImageId: string;
+					name: string;
+					seals: { title: string; description: string; logoMediaId: string }[];
+			  }
 			| undefined = undefined;
 		if (product.baseInfo.ownerType === OwnerType.COMMUNITY) {
 			const community = await this.communityRepository.getById(
@@ -181,10 +196,10 @@ export class GetByIdTextileProductDetailUseCase {
 			if (community) {
 				const seals = community.seals
 					? await Promise.all(
-						community.seals.map((sealId) =>
-							this.sealRepository.getById(sealId),
-						),
-					)
+							community.seals.map((sealId) =>
+								this.sealRepository.getById(sealId),
+							),
+						)
 					: [];
 
 				communityInfo = {
@@ -201,7 +216,7 @@ export class GetByIdTextileProductDetailUseCase {
 			}
 		}
 
-		// 15. Obtener category name
+		// -- Obtener category name
 		let categoryName = '';
 		if (product.categoryId) {
 			const category = await this.textileCategoryRepository.getCategoryById(
@@ -210,9 +225,10 @@ export class GetByIdTextileProductDetailUseCase {
 			categoryName = category?.name || '';
 		}
 
-		// 16. Construir respuesta completa
+		// -- Construir respuesta completa
 		return {
 			name: product.baseInfo.title,
+			images,
 			availableSizes,
 			availableColors,
 			availableMaterials,

--- a/src/andean/textileProduct.module.ts
+++ b/src/andean/textileProduct.module.ts
@@ -107,6 +107,8 @@ import { CommunitySchema } from './infra/persistence/community/community.schema'
 import { ReviewSchema } from './infra/persistence/Review.schema';
 import { ReviewRepository } from './app/datastore/Review.repo';
 import { ReviewRepositoryImpl } from './infra/datastore/Review.repo.impl';
+import { MediaItemRepository } from './app/datastore/MediaItem.repo';
+import { MediaItemRepoImpl } from './infra/datastore/mediaItem.repo.impl';
 import { CreateReviewUseCase } from './app/use_cases/CreateReviewUseCase';
 import { GetAllReviewsUseCase } from './app/use_cases/GetAllReviewsUseCase';
 import { GetByIdReviewUseCase } from './app/use_cases/GetByIdReviewUseCase';
@@ -119,6 +121,7 @@ import { DecrementDislikesUseCase } from './app/use_cases/DecrementDislikesUseCa
 import { SuperfoodModule } from './superfood.module';
 import { VariantModule } from './variant.module';
 import { VariantSchema } from './infra/persistence/variant.schema';
+import { MediaItemSchema } from './infra/persistence/mediaItem.schema';
 
 @Module({
 	imports: [
@@ -174,6 +177,10 @@ import { VariantSchema } from './infra/persistence/variant.schema';
 			{
 				name: 'Variant',
 				schema: VariantSchema,
+			},
+			{
+				name: 'MediaItem',
+				schema: MediaItemSchema,
 			},
 		]),
 		UsersModule,
@@ -308,6 +315,10 @@ import { VariantSchema } from './infra/persistence/variant.schema';
 			provide: ReviewRepository,
 			useClass: ReviewRepositoryImpl,
 		},
+		{
+			provide: MediaItemRepository,
+			useClass: MediaItemRepoImpl,
+		},
 	],
 	exports: [
 		TextileCategoryRepository,
@@ -321,7 +332,8 @@ import { VariantSchema } from './infra/persistence/variant.schema';
 		ColorOptionAlternativeRepository,
 		SizeOptionAlternativeRepository,
 		ReviewRepository,
+		MediaItemRepository,
 		MongooseModule,
 	],
 })
-export class TextileProductModule { }
+export class TextileProductModule {}


### PR DESCRIPTION
- Added MediaItemRepository and MediaItemRepoImpl to TextileProductModule for managing media items.
- Updated TextileProductDetailResponse to include media images with detailed properties.
- Modified GetByIdTextileProductDetailUseCase to fetch media items and include them in the product response.
- Improved API documentation with new media item properties in response models.