### PR TITLE
fix: resolve circular import between StockReducerRegistry and BoxStockReducer

### DIFF
--- a/src/andean/infra/services/stock/BoxStockReducer.ts
+++ b/src/andean/infra/services/stock/BoxStockReducer.ts
@@ -1,15 +1,10 @@
-import {
-	Injectable,
-	Inject,
-	NotFoundException,
-	forwardRef,
-} from '@nestjs/common';
+import { Injectable, Inject, NotFoundException } from '@nestjs/common';
 import { StockReducerStrategy } from './StockReducerStrategy';
 import { ProductType } from '../../../domain/enums/ProductType';
 import { BoxProductType } from '../../../domain/enums/BoxProductType';
 import { StockReductionItem } from '../../../domain/interfaces/StockReductionItem';
 import { BoxRepository } from '../../../app/datastore/box/Box.repo';
-import { StockReducerRegistry } from './StockReducerRegistry';
+import { IStockReducerRegistry } from './IStockReducerRegistry';
 
 const BOX_PRODUCT_TYPE_MAP: Record<BoxProductType, ProductType> = {
 	[BoxProductType.TEXTILE]: ProductType.TEXTILE,
@@ -23,8 +18,8 @@ export class BoxStockReducer extends StockReducerStrategy {
 	constructor(
 		@Inject(BoxRepository)
 		private readonly boxRepository: BoxRepository,
-		@Inject(forwardRef(() => StockReducerRegistry))
-		private readonly stockReducerRegistry: StockReducerRegistry,
+		@Inject(IStockReducerRegistry)
+		private readonly stockReducerRegistry: IStockReducerRegistry,
 	) {
 		super();
 	}

--- a/src/andean/infra/services/stock/IStockReducerRegistry.ts
+++ b/src/andean/infra/services/stock/IStockReducerRegistry.ts
@@ -1,0 +1,8 @@
+import { StockReductionItem } from '../../../domain/interfaces/StockReductionItem';
+
+export const IStockReducerRegistry = Symbol('IStockReducerRegistry');
+
+export interface IStockReducerRegistry {
+	reduceStock(item: StockReductionItem): Promise<void>;
+	reduceStockForItems(items: StockReductionItem[]): Promise<void>;
+}

--- a/src/andean/infra/services/stock/StockReducerRegistry.ts
+++ b/src/andean/infra/services/stock/StockReducerRegistry.ts
@@ -1,23 +1,18 @@
-import {
-	Injectable,
-	NotFoundException,
-	forwardRef,
-	Inject,
-} from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { StockReductionItem } from '../../../domain/interfaces/StockReductionItem';
 import { StockReducerStrategy } from './StockReducerStrategy';
 import { TextileStockReducer } from './TextileStockReducer';
 import { SuperfoodStockReducer } from './SuperfoodStockReducer';
 import { BoxStockReducer } from './BoxStockReducer';
+import { IStockReducerRegistry } from './IStockReducerRegistry';
 
 @Injectable()
-export class StockReducerRegistry {
+export class StockReducerRegistry implements IStockReducerRegistry {
 	private readonly reducers: StockReducerStrategy[];
 
 	constructor(
 		private readonly textileReducer: TextileStockReducer,
 		private readonly superfoodReducer: SuperfoodStockReducer,
-		@Inject(forwardRef(() => BoxStockReducer))
 		private readonly boxReducer: BoxStockReducer,
 	) {
 		this.reducers = [

--- a/src/andean/order.module.ts
+++ b/src/andean/order.module.ts
@@ -29,6 +29,7 @@ import { TextileStockReducer } from './infra/services/stock/TextileStockReducer'
 import { SuperfoodStockReducer } from './infra/services/stock/SuperfoodStockReducer';
 import { BoxStockReducer } from './infra/services/stock/BoxStockReducer';
 import { StockReducerRegistry } from './infra/services/stock/StockReducerRegistry';
+import { IStockReducerRegistry } from './infra/services/stock/IStockReducerRegistry';
 
 @Module({
 	imports: [
@@ -71,6 +72,10 @@ import { StockReducerRegistry } from './infra/services/stock/StockReducerRegistr
 		SuperfoodStockReducer,
 		BoxStockReducer,
 		StockReducerRegistry,
+		{
+			provide: IStockReducerRegistry,
+			useExisting: StockReducerRegistry,
+		},
 		ReduceStockFromOrderUseCase,
 	],
 	exports: [OrderRepository],


### PR DESCRIPTION
Descripción:
- Agregar interfaz IStockReducerRegistry con su Symbol como token de inyección
- StockReducerRegistry implementa IStockReducerRegistry y se elimina forwardRef
- BoxStockReducer inyecta por token IStockReducerRegistry en lugar de la clase concreta
- Registrar { provide: IStockReducerRegistry, useExisting: StockReducerRegistry } en OrdersModule