### PR TITLE
feat(superfoods/boxes): expose SIZE variants and hydrate box/cart display data

### DIFF
--- a/src/andean/app/models/box/BoxAdminEditResponse.ts
+++ b/src/andean/app/models/box/BoxAdminEditResponse.ts
@@ -1,0 +1,112 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { AdminEntityStatus } from '../../../domain/enums/AdminEntityStatus';
+import { BoxProductType } from '../../../domain/enums/BoxProductType';
+import { BoxProduct } from '../../../domain/entities/box/Box';
+import {
+	BoxCatalogMediaItemDto,
+	BoxCatalogVariantItemDto,
+} from './catalog/BoxCatalogResponses';
+
+export class BoxAdminEditSlotDto {
+	@ApiPropertyOptional({
+		enum: BoxProductType,
+		nullable: true,
+		description: 'Tipo de la línea; null si el slot está vacío',
+	})
+	productType!: BoxProductType | null;
+
+	@ApiPropertyOptional({
+		nullable: true,
+		description: 'ID del producto de catálogo (padre de la variante)',
+	})
+	productId!: string | null;
+
+	@ApiPropertyOptional({ nullable: true })
+	variantId!: string | null;
+
+	@ApiProperty()
+	productTitle!: string;
+
+	@ApiProperty()
+	categoryName!: string;
+
+	@ApiProperty()
+	variantLabel!: string;
+
+	@ApiProperty({ description: 'Precio de catálogo de la variante' })
+	catalogPrice!: number;
+
+	@ApiProperty()
+	stock!: number;
+
+	@ApiProperty()
+	imageUrl!: string;
+
+	@ApiPropertyOptional({
+		description: 'Precio por línea persistido en el box',
+	})
+	boxPrice?: number;
+
+	@ApiPropertyOptional({ nullable: true })
+	narrativeImgId!: string | null;
+
+	@ApiProperty({
+		type: [BoxCatalogVariantItemDto],
+		description: 'Todas las variantes del producto (picker del formulario)',
+	})
+	variants!: BoxCatalogVariantItemDto[];
+
+	@ApiProperty({
+		type: [BoxCatalogMediaItemDto],
+		description: 'Imágenes del producto para narrativeImgId',
+	})
+	narrativeMedia!: BoxCatalogMediaItemDto[];
+}
+
+export class BoxAdminEditResponse {
+	@ApiProperty()
+	id!: string;
+
+	@ApiProperty()
+	name!: string;
+
+	@ApiProperty()
+	slogan!: string;
+
+	@ApiProperty()
+	narrative!: string;
+
+	@ApiProperty()
+	thumbnailImageId!: string;
+
+	@ApiProperty()
+	mainImageId!: string;
+
+	@ApiProperty({ type: [BoxProduct] })
+	products!: BoxProduct[];
+
+	@ApiProperty()
+	price!: number;
+
+	@ApiPropertyOptional()
+	discountPercentage?: number;
+
+	@ApiProperty({ type: [String] })
+	sealIds!: string[];
+
+	@ApiProperty({ enum: AdminEntityStatus })
+	status!: AdminEntityStatus;
+
+	@ApiProperty()
+	createdAt!: Date;
+
+	@ApiProperty()
+	updatedAt!: Date;
+
+	@ApiProperty({
+		type: [BoxAdminEditSlotDto],
+		description:
+			'Tres líneas hidratadas (producto, variante, media) para el formulario de edición',
+	})
+	slots!: BoxAdminEditSlotDto[];
+}

--- a/src/andean/app/models/box/BoxDetailResponse.ts
+++ b/src/andean/app/models/box/BoxDetailResponse.ts
@@ -118,7 +118,8 @@ export class BoxContainedProductResponse {
 	ownerInfo?: OwnerInfoResponse;
 
 	@ApiPropertyOptional({
-		description: 'Color de la variante (solo textiles)',
+		description:
+			'Color de la variante (textiles) o color de catálogo del paquete (superfoods)',
 		type: BoxContainedProductColorResponse,
 	})
 	color?: BoxContainedProductColorResponse;

--- a/src/andean/app/models/box/BoxDetailResponse.ts
+++ b/src/andean/app/models/box/BoxDetailResponse.ts
@@ -70,7 +70,8 @@ export class BoxContainedProductResponse {
 	title!: string;
 
 	@ApiProperty({
-		description: 'Imagen miniatura del producto',
+		description:
+			'Imagen de la variante incluida en el box (textiles: media del color/opción; superfoods: pack principal)',
 		type: BoxImageResponse,
 	})
 	thumbnailImage!: BoxImageResponse;

--- a/src/andean/app/models/box/BoxDetailResponse.ts
+++ b/src/andean/app/models/box/BoxDetailResponse.ts
@@ -125,7 +125,8 @@ export class BoxContainedProductResponse {
 	color?: BoxContainedProductColorResponse;
 
 	@ApiPropertyOptional({
-		description: 'Talla de la variante (solo textiles)',
+		description:
+			'Talla de la variante (textiles) o tamaño de paquete (superfoods, p. ej. "250 g")',
 		example: 'M',
 	})
 	size?: string;

--- a/src/andean/app/models/box/BoxListResponse.ts
+++ b/src/andean/app/models/box/BoxListResponse.ts
@@ -66,7 +66,8 @@ export class BoxListProductResponse {
 	color?: BoxListProductColorResponse;
 
 	@ApiProperty({
-		description: 'Talla de la variante (solo textiles)',
+		description:
+			'Talla de la variante (textiles) o tamaño de paquete (superfoods, p. ej. "250 g")',
 		example: 'M',
 		required: false,
 	})

--- a/src/andean/app/models/cart/ShoppingCartItemResponse.ts
+++ b/src/andean/app/models/cart/ShoppingCartItemResponse.ts
@@ -95,4 +95,11 @@ export class ShoppingCartItemResponse {
 		type: [BoxContentItemResponse],
 	})
 	boxContent?: BoxContentItemResponse[];
+
+	@ApiPropertyOptional({
+		description:
+			'Hex de fondo del paquete (solo SUPERFOOD, color de catálogo del producto)',
+		example: '#0E6851',
+	})
+	packageColorHex?: string;
 }

--- a/src/andean/app/models/superfoods/SuperfoodProductDetailResponse.ts
+++ b/src/andean/app/models/superfoods/SuperfoodProductDetailResponse.ts
@@ -122,6 +122,23 @@ export class ReviewsResponse {
 	comments!: ReviewCommentResponse[];
 }
 
+export class SuperfoodDetailVariantResponse {
+	@ApiProperty({ description: 'Id de la entidad Variant' })
+	variantId!: string;
+
+	@ApiProperty({ example: '500 g' })
+	label!: string;
+
+	@ApiProperty()
+	price!: number;
+
+	@ApiProperty()
+	stock!: number;
+
+	@ApiPropertyOptional({ example: 'SF-QUI-001-500G' })
+	sku?: string;
+}
+
 // ── Main response ────────────────────────────────────────────────────────
 export class SuperfoodProductDetailResponse {
 	@ApiProperty() id!: string;
@@ -178,6 +195,12 @@ export class SuperfoodProductDetailResponse {
 
 	@ApiPropertyOptional()
 	isDiscountActive?: boolean;
+
+	@ApiProperty({
+		type: [SuperfoodDetailVariantResponse],
+		description: 'Variantes SIZE para el hero y el carrito',
+	})
+	variants!: SuperfoodDetailVariantResponse[];
 }
 
 // ── Compact list item (for moreProducts) ─────────────────────────────────

--- a/src/andean/app/use_cases/boxes/GetAllBoxesUseCase.ts
+++ b/src/andean/app/use_cases/boxes/GetAllBoxesUseCase.ts
@@ -1,12 +1,17 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { BoxRepository } from '../../datastore/box/Box.repo';
+import { SuperfoodSizeOptionAlternativeRepository } from '../../datastore/superfoods/SuperfoodSizeOptionAlternative.repo';
 import {
 	BoxListPaginatedResponse,
 	BoxListItemResponse,
 	BoxListProductResponse,
 } from '../../models/box/BoxListResponse';
 import { ProductType } from '../../../domain/enums/ProductType';
-import { BoxProductResolutionService } from '../../../infra/services/box/BoxProductResolutionService';
+import { SuperfoodOptionName } from '../../../domain/enums/SuperfoodOptionName';
+import {
+	BoxListDependencies,
+	BoxProductResolutionService,
+} from '../../../infra/services/box/BoxProductResolutionService';
 import { Box } from '../../../domain/entities/box/Box';
 import { OwnerNameResolver } from '../../../infra/services/OwnerNameResolver';
 import { Variant } from '../../../domain/entities/Variant';
@@ -27,6 +32,8 @@ export class GetAllBoxesUseCase {
 		private readonly boxResolutionService: BoxProductResolutionService,
 		private readonly ownerNameResolver: OwnerNameResolver,
 		private readonly textileAttributesAssembler: TextileProductAttributesAssembler,
+		@Inject(SuperfoodSizeOptionAlternativeRepository)
+		private readonly sizeOptionAlternativeRepository: SuperfoodSizeOptionAlternativeRepository,
 	) {}
 
 	async handle(
@@ -66,6 +73,8 @@ export class GetAllBoxesUseCase {
 				: new Map<string, TextileProductAttributes>();
 
 		const ownerNameCache = new Map<string, string>();
+		const superfoodSizeLabelById =
+			await this.resolveSuperfoodSizeLabels(dependencies);
 		const enrichedBoxes: BoxListItemResponse[] = await Promise.all(
 			boxes.map(async (box) => {
 				let discartedPrice = 0;
@@ -90,6 +99,7 @@ export class GetAllBoxesUseCase {
 					dependencies.mediaMap,
 					ownerNameCache,
 					textileAttrsByProductId,
+					superfoodSizeLabelById,
 				);
 
 				const boxThumb = this.boxResolutionService.resolveImage(
@@ -146,6 +156,7 @@ export class GetAllBoxesUseCase {
 		mediaMap: Map<string, MediaItem>,
 		ownerNameCache: Map<string, string>,
 		textileAttrsByProductId: Map<string, TextileProductAttributes>,
+		superfoodSizeLabelById: Map<string, string>,
 	): Promise<BoxListProductResponse[]> {
 		const rows: BoxListProductResponse[] = [];
 
@@ -161,6 +172,10 @@ export class GetAllBoxesUseCase {
 				if (!superfood?.baseInfo?.title || !ownerType) continue;
 
 				const information = superfood.baseInfo.shortDescription?.trim() ?? '';
+				const sizeId = variant.combination?.SIZE?.trim();
+				const size = sizeId
+					? superfoodSizeLabelById.get(sizeId)?.trim()
+					: undefined;
 				rows.push({
 					name: superfood.baseInfo.title,
 					ownerType,
@@ -178,6 +193,7 @@ export class GetAllBoxesUseCase {
 							mediaMap,
 						),
 					...(information ? { information } : {}),
+					...(size ? { size } : {}),
 				});
 				continue;
 			}
@@ -241,5 +257,42 @@ export class GetAllBoxesUseCase {
 		const ownerName = await this.ownerNameResolver.resolve(ownerType, ownerId);
 		cache.set(cacheKey, ownerName);
 		return ownerName;
+	}
+
+	private async resolveSuperfoodSizeLabels(
+		deps: BoxListDependencies,
+	): Promise<Map<string, string>> {
+		const labelById = new Map<string, string>();
+		for (const product of deps.superfoodMap.values()) {
+			const values =
+				product.options?.find(
+					(option) => option.name === SuperfoodOptionName.SIZE,
+				)?.values ?? [];
+			for (const value of values) {
+				const alternativeId = value.idOptionAlternative?.trim();
+				const label = value.label?.trim();
+				if (alternativeId && label) {
+					labelById.set(alternativeId, label);
+				}
+			}
+		}
+
+		const missingIds = [
+			...new Set(
+				[...deps.variantMap.values()]
+					.filter((variant) => variant.productType === ProductType.SUPERFOOD)
+					.map((variant) => variant.combination?.SIZE?.trim())
+					.filter((id): id is string => Boolean(id) && !labelById.has(id)),
+			),
+		];
+		if (missingIds.length === 0) return labelById;
+
+		const alternatives =
+			await this.sizeOptionAlternativeRepository.getByIds(missingIds);
+		for (const alternative of alternatives) {
+			const label = alternative.nameLabel?.trim();
+			if (label) labelById.set(alternative.id, label);
+		}
+		return labelById;
 	}
 }

--- a/src/andean/app/use_cases/boxes/GetBoxCatalogSuperfoodProductMediaUseCase.ts
+++ b/src/andean/app/use_cases/boxes/GetBoxCatalogSuperfoodProductMediaUseCase.ts
@@ -7,7 +7,7 @@ import {
 	BoxCatalogMediaResponseDto,
 } from '../../models/box/catalog/BoxCatalogResponses';
 
-function collectSuperfoodMediaIds(
+export function collectSuperfoodMediaIds(
 	media: SuperfoodProductMedia | undefined,
 ): string[] {
 	if (!media) return [];

--- a/src/andean/app/use_cases/boxes/GetBoxDetailUseCase.ts
+++ b/src/andean/app/use_cases/boxes/GetBoxDetailUseCase.ts
@@ -1,6 +1,7 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { BoxRepository } from '../../datastore/box/Box.repo';
 import { BoxSealRepository } from '../../datastore/box/BoxSeal.repo';
+import { SuperfoodColorRepository } from '../../datastore/superfoods/SuperfoodColor.repo';
 import {
 	BoxDetailResponse,
 	BoxContainedProductResponse,
@@ -33,6 +34,8 @@ export class GetBoxDetailUseCase {
 		private readonly boxResolutionService: BoxProductResolutionService,
 		private readonly ownerInfoResolver: OwnerInfoResolver,
 		private readonly textileAttributesAssembler: TextileProductAttributesAssembler,
+		@Inject(SuperfoodColorRepository)
+		private readonly superfoodColorRepository: SuperfoodColorRepository,
 	) {}
 
 	async handle(boxId: string): Promise<BoxDetailResponse> {
@@ -250,6 +253,18 @@ export class GetBoxDetailUseCase {
 			ownerId,
 		};
 		if (ownerInfo) row.ownerInfo = ownerInfo;
+		const colorId = superfood.colorId?.trim();
+		if (colorId) {
+			const catalogColor =
+				await this.superfoodColorRepository.getById(colorId);
+			const hex = catalogColor?.hexCodeColor?.trim();
+			if (hex) {
+				row.color = {
+					label: catalogColor?.name?.trim() || 'Package',
+					hexCode: hex,
+				};
+			}
+		}
 		this.applyNarrativeImageIfPresent(row, narrativeImage);
 		return row;
 	}

--- a/src/andean/app/use_cases/boxes/GetBoxDetailUseCase.ts
+++ b/src/andean/app/use_cases/boxes/GetBoxDetailUseCase.ts
@@ -254,8 +254,10 @@ export class GetBoxDetailUseCase {
 			id: variant.productId,
 			variantId,
 			title: superfood.baseInfo?.title || '',
-			thumbnailImage: this.boxResolutionService.resolveImage(
-				superfood.baseInfo?.productMedia?.mainImgId,
+			thumbnailImage: this.boxResolutionService.resolveContainedProductThumbnail(
+				variant,
+				deps.textileMap,
+				deps.superfoodMap,
 				deps.mediaMap,
 			),
 			information: superfood.baseInfo?.shortDescription || '',
@@ -320,8 +322,10 @@ export class GetBoxDetailUseCase {
 			id: variant.productId,
 			variantId,
 			title: textile?.baseInfo?.title || '',
-			thumbnailImage: this.boxResolutionService.resolveImage(
-				textile?.baseInfo?.mediaIds?.[0],
+			thumbnailImage: this.boxResolutionService.resolveContainedProductThumbnail(
+				variant,
+				deps.textileMap,
+				deps.superfoodMap,
 				deps.mediaMap,
 			),
 			// Campo corto del producto (`information`), no la descripción larga.

--- a/src/andean/app/use_cases/boxes/GetBoxDetailUseCase.ts
+++ b/src/andean/app/use_cases/boxes/GetBoxDetailUseCase.ts
@@ -2,6 +2,7 @@ import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { BoxRepository } from '../../datastore/box/Box.repo';
 import { BoxSealRepository } from '../../datastore/box/BoxSeal.repo';
 import { SuperfoodColorRepository } from '../../datastore/superfoods/SuperfoodColor.repo';
+import { SuperfoodSizeOptionAlternativeRepository } from '../../datastore/superfoods/SuperfoodSizeOptionAlternative.repo';
 import {
 	BoxDetailResponse,
 	BoxContainedProductResponse,
@@ -21,6 +22,7 @@ import { BoxSeal } from '../../../domain/entities/box/BoxSeal';
 import { Variant } from '../../../domain/entities/Variant';
 import { MediaItem } from '../../../domain/entities/MediaItem';
 import { AdminEntityStatus } from '../../../domain/enums/AdminEntityStatus';
+import { SuperfoodOptionName } from '../../../domain/enums/SuperfoodOptionName';
 import {
 	TextileProductAttributes,
 	TextileProductAttributesAssembler,
@@ -36,6 +38,8 @@ export class GetBoxDetailUseCase {
 		private readonly textileAttributesAssembler: TextileProductAttributesAssembler,
 		@Inject(SuperfoodColorRepository)
 		private readonly superfoodColorRepository: SuperfoodColorRepository,
+		@Inject(SuperfoodSizeOptionAlternativeRepository)
+		private readonly sizeOptionAlternativeRepository: SuperfoodSizeOptionAlternativeRepository,
 	) {}
 
 	async handle(boxId: string): Promise<BoxDetailResponse> {
@@ -62,12 +66,15 @@ export class GetBoxDetailUseCase {
 						textileVariants,
 					)
 				: new Map<string, TextileProductAttributes>();
+		const superfoodSizeLabelById =
+			await this.resolveSuperfoodSizeLabels(dependencies);
 
 		const { containedProducts, discartedPrice } =
 			await this.buildContainedProducts(
 				box.products,
 				dependencies,
 				textileAttrsByProductId,
+				superfoodSizeLabelById,
 			);
 		const discartedPriceRounded = Math.round(discartedPrice);
 
@@ -138,6 +145,7 @@ export class GetBoxDetailUseCase {
 		lines: BoxProduct[],
 		deps: BoxDependencies,
 		textileAttrsByProductId: Map<string, TextileProductAttributes>,
+		superfoodSizeLabelById: Map<string, string>,
 	): Promise<{
 		containedProducts: BoxContainedProductResponse[];
 		discartedPrice: number;
@@ -150,6 +158,7 @@ export class GetBoxDetailUseCase {
 				line,
 				deps,
 				textileAttrsByProductId,
+				superfoodSizeLabelById,
 			);
 			if (!resolved) continue;
 			containedProducts.push(resolved.row);
@@ -163,6 +172,7 @@ export class GetBoxDetailUseCase {
 		line: BoxProduct,
 		deps: BoxDependencies,
 		textileAttrsByProductId: Map<string, TextileProductAttributes>,
+		superfoodSizeLabelById: Map<string, string>,
 	): Promise<{
 		row: BoxContainedProductResponse;
 		linePrice: number;
@@ -187,6 +197,7 @@ export class GetBoxDetailUseCase {
 				effectiveLinePrice,
 				narrativeImage,
 				deps,
+				superfoodSizeLabelById,
 			);
 			return row ? { row, linePrice: catalogPrice } : null;
 		}
@@ -228,6 +239,7 @@ export class GetBoxDetailUseCase {
 		effectiveLinePrice: number,
 		narrativeImage: BoxImageResponse | undefined,
 		deps: BoxDependencies,
+		sizeLabelById: Map<string, string>,
 	): Promise<BoxContainedProductResponse | null> {
 		const superfood = deps.superfoodMap.get(variant.productId);
 		if (!superfood) return null;
@@ -265,6 +277,9 @@ export class GetBoxDetailUseCase {
 				};
 			}
 		}
+		const sizeId = variant.combination?.SIZE?.trim();
+		const sizeLabel = sizeId ? sizeLabelById.get(sizeId)?.trim() : undefined;
+		if (sizeLabel) row.size = sizeLabel;
 		this.applyNarrativeImageIfPresent(row, narrativeImage);
 		return row;
 	}
@@ -351,5 +366,44 @@ export class GetBoxDetailUseCase {
 		return discartedPrice > 0
 			? Math.round((1 - box.price / discartedPrice) * 100)
 			: 0;
+	}
+
+	private async resolveSuperfoodSizeLabels(
+		deps: BoxDependencies,
+	): Promise<Map<string, string>> {
+		const labelById = new Map<string, string>();
+		for (const product of deps.superfoodMap.values()) {
+			const values =
+				product.options?.find(
+					(option) => option.name === SuperfoodOptionName.SIZE,
+				)?.values ?? [];
+			for (const value of values) {
+				const alternativeId = value.idOptionAlternative?.trim();
+				const label = value.label?.trim();
+				if (alternativeId && label) {
+					labelById.set(alternativeId, label);
+				}
+			}
+		}
+
+		const missingIds = [
+			...new Set(
+				[...deps.variantMap.values()]
+					.filter((variant) => variant.productType === ProductType.SUPERFOOD)
+					.map((variant) => variant.combination?.SIZE?.trim())
+					.filter(
+						(id): id is string => Boolean(id) && !labelById.has(id),
+					),
+			),
+		];
+		if (missingIds.length === 0) return labelById;
+
+		const alternatives =
+			await this.sizeOptionAlternativeRepository.getByIds(missingIds);
+		for (const alternative of alternatives) {
+			const label = alternative.nameLabel?.trim();
+			if (label) labelById.set(alternative.id, label);
+		}
+		return labelById;
 	}
 }

--- a/src/andean/app/use_cases/boxes/GetBoxForAdminEditUseCase.spec.ts
+++ b/src/andean/app/use_cases/boxes/GetBoxForAdminEditUseCase.spec.ts
@@ -1,0 +1,201 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { GetBoxForAdminEditUseCase } from './GetBoxForAdminEditUseCase';
+import { BoxRepository } from '../../datastore/box/Box.repo';
+import { VariantRepository } from '../../datastore/Variant.repo';
+import { SuperfoodSizeOptionAlternativeRepository } from '../../datastore/superfoods/SuperfoodSizeOptionAlternative.repo';
+import { SuperfoodCategoryRepository } from '../../datastore/superfoods/SuperfoodCategory.repo';
+import { TextileCategoryRepository } from '../../datastore/textileProducts/TextileCategory.repo';
+import { BoxProductResolutionService } from '../../../infra/services/box/BoxProductResolutionService';
+import { TextileVariantPickerMediaService } from '../../../infra/services/box/TextileVariantPickerMediaService';
+import { MediaUrlResolver } from '../../../infra/services/media/MediaUrlResolver';
+import { Box, BoxProduct } from '../../../domain/entities/box/Box';
+import { BoxProductType } from '../../../domain/enums/BoxProductType';
+import { AdminEntityStatus } from '../../../domain/enums/AdminEntityStatus';
+import { Variant } from '../../../domain/entities/Variant';
+import { ProductType } from '../../../domain/enums/ProductType';
+import { SuperfoodProduct } from '../../../domain/entities/superfoods/SuperfoodProduct';
+import { SizeOptionAlternative } from '../../../domain/entities/superfoods/SizeOptionAlternative';
+import { SuperfoodCategory } from '../../../domain/entities/superfoods/SuperfoodCategory';
+
+const SIZE_ID = '6a7f3b37747108abdddbcd23';
+const VARIANT_ID = 'variant-1';
+const PRODUCT_ID = 'product-1';
+
+function emptyBox(products: BoxProduct[] = []): Box {
+	return new Box(
+		'box-1',
+		'Andean Box',
+		'Slogan',
+		'Narrative',
+		'thumb-id',
+		'main-id',
+		products,
+		AdminEntityStatus.HIDDEN,
+		99,
+		10,
+		['seal-1'],
+		new Date('2026-01-01'),
+		new Date('2026-01-02'),
+	);
+}
+
+describe('GetBoxForAdminEditUseCase', () => {
+	let useCase: GetBoxForAdminEditUseCase;
+	let boxRepository: { getById: jest.Mock };
+	let boxResolutionService: { bulkFetchBoxDependencies: jest.Mock };
+	let variantRepository: { getByProductId: jest.Mock };
+	let sizeOptionRepository: { getByIds: jest.Mock };
+	let superfoodCategoryRepository: { getCategoryById: jest.Mock };
+	let textileCategoryRepository: { getCategoryById: jest.Mock };
+	let textileVariantPickerMediaService: {
+		resolveVariantMainMediaId: jest.Mock;
+		buildVariantLabel: jest.Mock;
+	};
+	let mediaUrlResolver: { resolveUrls: jest.Mock };
+
+	beforeEach(async () => {
+		boxRepository = { getById: jest.fn() };
+		boxResolutionService = { bulkFetchBoxDependencies: jest.fn() };
+		variantRepository = { getByProductId: jest.fn() };
+		sizeOptionRepository = { getByIds: jest.fn() };
+		superfoodCategoryRepository = { getCategoryById: jest.fn() };
+		textileCategoryRepository = { getCategoryById: jest.fn() };
+		textileVariantPickerMediaService = {
+			resolveVariantMainMediaId: jest.fn(),
+			buildVariantLabel: jest.fn(),
+		};
+		mediaUrlResolver = { resolveUrls: jest.fn() };
+
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [
+				GetBoxForAdminEditUseCase,
+				{ provide: BoxRepository, useValue: boxRepository },
+				{
+					provide: BoxProductResolutionService,
+					useValue: boxResolutionService,
+				},
+				{ provide: VariantRepository, useValue: variantRepository },
+				{
+					provide: SuperfoodSizeOptionAlternativeRepository,
+					useValue: sizeOptionRepository,
+				},
+				{
+					provide: SuperfoodCategoryRepository,
+					useValue: superfoodCategoryRepository,
+				},
+				{
+					provide: TextileCategoryRepository,
+					useValue: textileCategoryRepository,
+				},
+				{
+					provide: TextileVariantPickerMediaService,
+					useValue: textileVariantPickerMediaService,
+				},
+				{ provide: MediaUrlResolver, useValue: mediaUrlResolver },
+			],
+		}).compile();
+
+		useCase = module.get(GetBoxForAdminEditUseCase);
+	});
+
+	it('throws when the box does not exist', async () => {
+		boxRepository.getById.mockResolvedValue(null);
+		await expect(useCase.handle('missing')).rejects.toThrow(NotFoundException);
+	});
+
+	it('returns three empty slots when the box has no products', async () => {
+		const box = emptyBox();
+		boxRepository.getById.mockResolvedValue(box);
+		boxResolutionService.bulkFetchBoxDependencies.mockResolvedValue({
+			superfoodMap: new Map(),
+			textileMap: new Map(),
+			variantMap: new Map(),
+			mediaMap: new Map(),
+		});
+		mediaUrlResolver.resolveUrls.mockResolvedValue(new Map());
+
+		const result = await useCase.handle(box.id);
+
+		expect(result.slots).toHaveLength(3);
+		expect(result.slots.every((slot) => slot.productId === null)).toBe(true);
+		expect(result.name).toBe('Andean Box');
+		expect(variantRepository.getByProductId).not.toHaveBeenCalled();
+	});
+
+	it('hydrates a superfood line with variants, size label and media', async () => {
+		const line = new BoxProduct(
+			BoxProductType.SUPERFOOD,
+			VARIANT_ID,
+			40,
+			'nar-1',
+		);
+		const box = emptyBox([line]);
+		const variant = new Variant(
+			VARIANT_ID,
+			PRODUCT_ID,
+			ProductType.SUPERFOOD,
+			{ SIZE: SIZE_ID },
+			50,
+			8,
+			new Date(),
+			new Date(),
+		);
+		const product = {
+			id: PRODUCT_ID,
+			categoryId: 'cat-1',
+			baseInfo: {
+				title: 'Sacha Inchi',
+				productMedia: {
+					mainImgId: 'main-img',
+					otherImagesId: ['nar-1'],
+				},
+			},
+		} as SuperfoodProduct;
+
+		boxRepository.getById.mockResolvedValue(box);
+		boxResolutionService.bulkFetchBoxDependencies.mockResolvedValue({
+			superfoodMap: new Map([[PRODUCT_ID, product]]),
+			textileMap: new Map(),
+			variantMap: new Map([[VARIANT_ID, variant]]),
+			mediaMap: new Map(),
+		});
+		variantRepository.getByProductId.mockResolvedValue([variant]);
+		sizeOptionRepository.getByIds.mockResolvedValue([
+			new SizeOptionAlternative(SIZE_ID, '250 g', 250, 'g', 10),
+		]);
+		superfoodCategoryRepository.getCategoryById.mockResolvedValue(
+			new SuperfoodCategory('cat-1', 'Seeds', 'ENABLED'),
+		);
+		mediaUrlResolver.resolveUrls.mockResolvedValue(
+			new Map([
+				['main-img', 'https://cdn/main.png'],
+				['nar-1', 'https://cdn/nar.png'],
+			]),
+		);
+
+		const result = await useCase.handle(box.id);
+		const slot = result.slots[0];
+
+		expect(slot?.productType).toBe(BoxProductType.SUPERFOOD);
+		expect(slot?.productId).toBe(PRODUCT_ID);
+		expect(slot?.variantId).toBe(VARIANT_ID);
+		expect(slot?.productTitle).toBe('Sacha Inchi');
+		expect(slot?.categoryName).toBe('Seeds');
+		expect(slot?.variantLabel).toBe('250 g');
+		expect(slot?.catalogPrice).toBe(50);
+		expect(slot?.stock).toBe(8);
+		expect(slot?.imageUrl).toBe('https://cdn/main.png');
+		expect(slot?.boxPrice).toBe(40);
+		expect(slot?.narrativeImgId).toBe('nar-1');
+		expect(slot?.variants).toHaveLength(1);
+		expect(slot?.narrativeMedia).toEqual(
+			expect.arrayContaining([
+				{ id: 'main-img', url: 'https://cdn/main.png' },
+				{ id: 'nar-1', url: 'https://cdn/nar.png' },
+			]),
+		);
+		expect(result.slots[1]?.productId).toBeNull();
+		expect(result.slots[2]?.productId).toBeNull();
+	});
+});

--- a/src/andean/app/use_cases/boxes/GetBoxForAdminEditUseCase.ts
+++ b/src/andean/app/use_cases/boxes/GetBoxForAdminEditUseCase.ts
@@ -1,16 +1,386 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { BoxRepository } from '../../datastore/box/Box.repo';
-import { Box } from '../../../domain/entities/box/Box';
+import { VariantRepository } from '../../datastore/Variant.repo';
+import { SuperfoodSizeOptionAlternativeRepository } from '../../datastore/superfoods/SuperfoodSizeOptionAlternative.repo';
+import { SuperfoodCategoryRepository } from '../../datastore/superfoods/SuperfoodCategory.repo';
+import { TextileCategoryRepository } from '../../datastore/textileProducts/TextileCategory.repo';
+import { BoxProductResolutionService } from '../../../infra/services/box/BoxProductResolutionService';
+import { TextileVariantPickerMediaService } from '../../../infra/services/box/TextileVariantPickerMediaService';
+import { MediaUrlResolver } from '../../../infra/services/media/MediaUrlResolver';
+import { collectSuperfoodMediaIds } from './GetBoxCatalogSuperfoodProductMediaUseCase';
+import {
+	BoxAdminEditResponse,
+	BoxAdminEditSlotDto,
+} from '../../models/box/BoxAdminEditResponse';
+import {
+	BoxCatalogMediaItemDto,
+	BoxCatalogVariantItemDto,
+} from '../../models/box/catalog/BoxCatalogResponses';
+import { BoxProduct } from '../../../domain/entities/box/Box';
+import { SuperfoodProduct } from '../../../domain/entities/superfoods/SuperfoodProduct';
+import { TextileProduct } from '../../../domain/entities/textileProducts/TextileProduct';
+import { Variant } from '../../../domain/entities/Variant';
+import { ProductType } from '../../../domain/enums/ProductType';
+import { BoxProductType } from '../../../domain/enums/BoxProductType';
+
+const SLOT_COUNT = 3;
 
 @Injectable()
 export class GetBoxForAdminEditUseCase {
-	constructor(private readonly boxRepository: BoxRepository) {}
+	constructor(
+		private readonly boxRepository: BoxRepository,
+		private readonly boxResolutionService: BoxProductResolutionService,
+		@Inject(VariantRepository)
+		private readonly variantRepository: VariantRepository,
+		@Inject(SuperfoodSizeOptionAlternativeRepository)
+		private readonly sizeOptionAlternativeRepository: SuperfoodSizeOptionAlternativeRepository,
+		@Inject(SuperfoodCategoryRepository)
+		private readonly superfoodCategoryRepository: SuperfoodCategoryRepository,
+		@Inject(TextileCategoryRepository)
+		private readonly textileCategoryRepository: TextileCategoryRepository,
+		private readonly textileVariantPickerMediaService: TextileVariantPickerMediaService,
+		private readonly mediaUrlResolver: MediaUrlResolver,
+	) {}
 
-	async handle(boxId: string): Promise<Box> {
+	async handle(boxId: string): Promise<BoxAdminEditResponse> {
 		const box = await this.boxRepository.getById(boxId);
 		if (!box) {
 			throw new NotFoundException(`Box with id ${boxId} not found`);
 		}
-		return box;
+
+		const deps = await this.boxResolutionService.bulkFetchBoxDependencies([
+			box,
+		]);
+
+		const productIds = [
+			...new Set(
+				[...deps.variantMap.values()]
+					.map((variant) => variant.productId?.trim())
+					.filter((id): id is string => Boolean(id)),
+			),
+		];
+
+		const variantsByProductId = new Map<string, Variant[]>();
+		await Promise.all(
+			productIds.map(async (productId) => {
+				const list = await this.variantRepository.getByProductId(productId);
+				variantsByProductId.set(productId, list);
+			}),
+		);
+
+		const sizeAlternativeIds = [
+			...new Set(
+				[...variantsByProductId.values()]
+					.flat()
+					.filter((variant) => variant.productType === ProductType.SUPERFOOD)
+					.map((variant) => variant.combination?.SIZE?.trim())
+					.filter((id): id is string => Boolean(id)),
+			),
+		];
+		const sizeAlternatives =
+			sizeAlternativeIds.length > 0
+				? await this.sizeOptionAlternativeRepository.getByIds(
+						sizeAlternativeIds,
+					)
+				: [];
+		const sizeLabelById = new Map(
+			sizeAlternatives.map((option) => [option.id, option.nameLabel]),
+		);
+
+		const superfoodCategoryIds = [
+			...new Set(
+				[...deps.superfoodMap.values()]
+					.map((product) => product.categoryId?.trim())
+					.filter((id): id is string => Boolean(id)),
+			),
+		];
+		const textileCategoryIds = [
+			...new Set(
+				[...deps.textileMap.values()]
+					.map((product) => product.categoryId?.trim())
+					.filter((id): id is string => Boolean(id)),
+			),
+		];
+		const [superfoodCategories, textileCategories] = await Promise.all([
+			Promise.all(
+				superfoodCategoryIds.map((id) =>
+					this.superfoodCategoryRepository.getCategoryById(id),
+				),
+			),
+			Promise.all(
+				textileCategoryIds.map((id) =>
+					this.textileCategoryRepository.getCategoryById(id),
+				),
+			),
+		]);
+		const superfoodCategoryNameById = new Map(
+			superfoodCategories
+				.filter((category): category is NonNullable<typeof category> =>
+					Boolean(category),
+				)
+				.map((category) => [category.id, category.name]),
+		);
+		const textileCategoryNameById = new Map(
+			textileCategories
+				.filter((category): category is NonNullable<typeof category> =>
+					Boolean(category),
+				)
+				.map((category) => [category.id, category.name]),
+		);
+
+		const mediaIds = new Set<string>();
+		for (const product of deps.superfoodMap.values()) {
+			for (const id of collectSuperfoodMediaIds(
+				product.baseInfo?.productMedia,
+			)) {
+				mediaIds.add(id);
+			}
+		}
+		for (const product of deps.textileMap.values()) {
+			for (const id of product.baseInfo?.mediaIds ?? []) {
+				const trimmed = id?.trim();
+				if (trimmed) mediaIds.add(trimmed);
+			}
+			const productVariants = variantsByProductId.get(product.id) ?? [];
+			for (const variant of productVariants) {
+				const mid =
+					this.textileVariantPickerMediaService.resolveVariantMainMediaId(
+						product,
+						variant,
+					);
+				if (mid) mediaIds.add(mid);
+			}
+		}
+		for (const line of box.products) {
+			const nar = line.narrativeImgId?.trim();
+			if (nar) mediaIds.add(nar);
+		}
+
+		const urlMap = await this.mediaUrlResolver.resolveUrls([...mediaIds]);
+
+		const slots: BoxAdminEditSlotDto[] = [];
+		for (let i = 0; i < SLOT_COUNT; i++) {
+			slots.push(
+				this.buildSlot(
+					box.products[i],
+					deps.variantMap,
+					deps.superfoodMap,
+					deps.textileMap,
+					variantsByProductId,
+					sizeLabelById,
+					superfoodCategoryNameById,
+					textileCategoryNameById,
+					urlMap,
+				),
+			);
+		}
+
+		return {
+			id: box.id,
+			name: box.name,
+			slogan: box.slogan,
+			narrative: box.narrative,
+			thumbnailImageId: box.thumbnailImageId,
+			mainImageId: box.mainImageId,
+			products: box.products,
+			price: box.price,
+			discountPercentage: box.discountPercentage,
+			sealIds: box.sealIds ?? [],
+			status: box.status,
+			createdAt: box.createdAt,
+			updatedAt: box.updatedAt,
+			slots,
+		};
+	}
+
+	private buildSlot(
+		line: BoxProduct | undefined,
+		variantMap: Map<string, Variant>,
+		superfoodMap: Map<string, SuperfoodProduct>,
+		textileMap: Map<string, TextileProduct>,
+		variantsByProductId: Map<string, Variant[]>,
+		sizeLabelById: Map<string, string>,
+		superfoodCategoryNameById: Map<string, string>,
+		textileCategoryNameById: Map<string, string>,
+		urlMap: Map<string, string>,
+	): BoxAdminEditSlotDto {
+		const empty = this.emptySlot();
+		const variantId = line?.variantId?.trim();
+		if (!line || !variantId) return empty;
+
+		const productType =
+			line.productType === BoxProductType.SUPERFOOD ||
+			line.productType === BoxProductType.TEXTILE
+				? line.productType
+				: null;
+		const variant = variantMap.get(variantId);
+		if (!variant) {
+			return {
+				...empty,
+				productType,
+				variantId,
+				boxPrice: line.boxPrice,
+				narrativeImgId: line.narrativeImgId?.trim() || null,
+			};
+		}
+
+		if (variant.productType === ProductType.SUPERFOOD) {
+			const product = superfoodMap.get(variant.productId);
+			const productVariants =
+				variantsByProductId.get(variant.productId) ?? [variant];
+			const mainImgId = product?.baseInfo?.productMedia?.mainImgId?.trim();
+			const imgUrl = mainImgId ? (urlMap.get(mainImgId) ?? '') : '';
+			const variants = productVariants
+				.filter((item) => item.productType === ProductType.SUPERFOOD)
+				.map((item) =>
+					this.toSuperfoodVariantDto(item, imgUrl, sizeLabelById),
+				);
+			const selected =
+				variants.find((item) => item.id === variantId) ?? variants[0];
+			const narrativeMedia = this.toSuperfoodNarrativeMedia(product, urlMap);
+			const narrativeImgId =
+				line.narrativeImgId?.trim() || narrativeMedia[0]?.id || null;
+			return {
+				productType: BoxProductType.SUPERFOOD,
+				productId: variant.productId,
+				variantId,
+				productTitle: product?.baseInfo?.title ?? '',
+				categoryName: product?.categoryId
+					? (superfoodCategoryNameById.get(product.categoryId) ?? '')
+					: '',
+				variantLabel: selected?.label ?? '',
+				catalogPrice: selected?.price ?? variant.price,
+				stock: selected?.stock ?? variant.stock,
+				imageUrl: selected?.imgUrl || imgUrl,
+				boxPrice: line.boxPrice,
+				narrativeImgId,
+				variants,
+				narrativeMedia,
+			};
+		}
+
+		if (variant.productType === ProductType.TEXTILE) {
+			const product = textileMap.get(variant.productId);
+			const productVariants =
+				variantsByProductId.get(variant.productId) ?? [variant];
+			const textileVariants = productVariants.filter(
+				(item) => item.productType === ProductType.TEXTILE,
+			);
+			const variants = textileVariants.map((item) =>
+				this.toTextileVariantDto(item, product, urlMap),
+			);
+			const selected =
+				variants.find((item) => item.id === variantId) ?? variants[0];
+			const narrativeMedia = this.toTextileNarrativeMedia(product, urlMap);
+			const fallbackImg =
+				product?.baseInfo?.mediaIds?.[0]?.trim()
+					? (urlMap.get(product.baseInfo.mediaIds[0].trim()) ?? '')
+					: '';
+			const narrativeImgId =
+				line.narrativeImgId?.trim() || narrativeMedia[0]?.id || null;
+			return {
+				productType: BoxProductType.TEXTILE,
+				productId: variant.productId,
+				variantId,
+				productTitle: product?.baseInfo?.title ?? '',
+				categoryName: product?.categoryId
+					? (textileCategoryNameById.get(product.categoryId) ?? '')
+					: '',
+				variantLabel: selected?.label ?? '',
+				catalogPrice: selected?.price ?? variant.price,
+				stock: selected?.stock ?? variant.stock,
+				imageUrl: selected?.imgUrl || fallbackImg,
+				boxPrice: line.boxPrice,
+				narrativeImgId,
+				variants,
+				narrativeMedia,
+			};
+		}
+
+		return {
+			...empty,
+			productType,
+			variantId,
+			boxPrice: line.boxPrice,
+			narrativeImgId: line.narrativeImgId?.trim() || null,
+		};
+	}
+
+	private emptySlot(): BoxAdminEditSlotDto {
+		return {
+			productType: null,
+			productId: null,
+			variantId: null,
+			productTitle: '',
+			categoryName: '',
+			variantLabel: '',
+			catalogPrice: 0,
+			stock: 0,
+			imageUrl: '',
+			narrativeImgId: null,
+			variants: [],
+			narrativeMedia: [],
+		};
+	}
+
+	private toSuperfoodVariantDto(
+		variant: Variant,
+		imgUrl: string,
+		sizeLabelById: Map<string, string>,
+	): BoxCatalogVariantItemDto {
+		const sizeId = variant.combination?.SIZE?.trim();
+		return {
+			id: variant.id,
+			label:
+				(sizeId ? sizeLabelById.get(sizeId) : undefined) ||
+				(sizeId ? `Size ${sizeId}` : 'Superfood variant'),
+			imgUrl,
+			price: variant.price,
+			stock: variant.stock,
+			combination: { ...variant.combination },
+		};
+	}
+
+	private toTextileVariantDto(
+		variant: Variant,
+		product: TextileProduct | undefined,
+		urlMap: Map<string, string>,
+	): BoxCatalogVariantItemDto {
+		const mediaId = product
+			? this.textileVariantPickerMediaService.resolveVariantMainMediaId(
+					product,
+					variant,
+				)
+			: null;
+		return {
+			id: variant.id,
+			label: this.textileVariantPickerMediaService.buildVariantLabel(variant),
+			imgUrl: mediaId ? (urlMap.get(mediaId) ?? '') : '',
+			price: variant.price,
+			stock: variant.stock,
+			combination: { ...variant.combination },
+		};
+	}
+
+	private toSuperfoodNarrativeMedia(
+		product: SuperfoodProduct | undefined,
+		urlMap: Map<string, string>,
+	): BoxCatalogMediaItemDto[] {
+		const ids = collectSuperfoodMediaIds(product?.baseInfo?.productMedia);
+		return ids.map((id) => ({ id, url: urlMap.get(id) ?? '' }));
+	}
+
+	private toTextileNarrativeMedia(
+		product: TextileProduct | undefined,
+		urlMap: Map<string, string>,
+	): BoxCatalogMediaItemDto[] {
+		const ids = [
+			...new Set(
+				(product?.baseInfo?.mediaIds ?? [])
+					.map((id) => id?.trim())
+					.filter((id): id is string => Boolean(id)),
+			),
+		];
+		return ids.map((id) => ({ id, url: urlMap.get(id) ?? '' }));
 	}
 }

--- a/src/andean/app/use_cases/cart_shop/AddItemToCartUseCase.ts
+++ b/src/andean/app/use_cases/cart_shop/AddItemToCartUseCase.ts
@@ -24,6 +24,7 @@ import { CartColorOptionResponse } from '../../models/cart/CartColorOptionRespon
 import { TextileProductRepository } from '../../datastore/textileProducts/TextileProduct.repo';
 import { BoxCartAvailabilityService } from '../../../infra/services/cart/BoxCartAvailabilityService';
 import { BoxCartContentResolver } from '../../../infra/services/cart/BoxCartContentResolver';
+import { SuperfoodCartSizeResolver } from '../../../infra/services/cart/SuperfoodCartSizeResolver';
 import { Variant } from '../../../domain/entities/Variant';
 
 @Injectable()
@@ -44,6 +45,7 @@ export class AddItemToCartUseCase {
 		private readonly textileProductRepository: TextileProductRepository,
 		private readonly boxCartAvailability: BoxCartAvailabilityService,
 		private readonly boxCartContentResolver: BoxCartContentResolver,
+		private readonly superfoodCartSizeResolver: SuperfoodCartSizeResolver,
 	) {}
 
 	async handle(
@@ -152,6 +154,8 @@ export class AddItemToCartUseCase {
 		);
 
 		const colorOption = await this.resolveTextileColorOption(variant);
+		const displayCombination =
+			await this.superfoodCartSizeResolver.toDisplayCombination(variant);
 
 		const cart = await this.ensureCart(customerId);
 		const existingCartItems =
@@ -188,6 +192,7 @@ export class AddItemToCartUseCase {
 				productInfo,
 				ownerName,
 				colorOption,
+				displayCombination,
 			);
 		}
 
@@ -213,6 +218,7 @@ export class AddItemToCartUseCase {
 			ownerName,
 			quantity,
 			colorOption,
+			displayCombination,
 		});
 	}
 

--- a/src/andean/app/use_cases/cart_shop/AddItemToCartUseCase.ts
+++ b/src/andean/app/use_cases/cart_shop/AddItemToCartUseCase.ts
@@ -154,8 +154,8 @@ export class AddItemToCartUseCase {
 		);
 
 		const colorOption = await this.resolveTextileColorOption(variant);
-		const displayCombination =
-			await this.superfoodCartSizeResolver.toDisplayCombination(variant);
+		const { displayCombination, packageColorHex } =
+			await this.superfoodCartSizeResolver.enrich(variant);
 
 		const cart = await this.ensureCart(customerId);
 		const existingCartItems =
@@ -193,6 +193,7 @@ export class AddItemToCartUseCase {
 				ownerName,
 				colorOption,
 				displayCombination,
+				packageColorHex,
 			);
 		}
 
@@ -219,6 +220,7 @@ export class AddItemToCartUseCase {
 			quantity,
 			colorOption,
 			displayCombination,
+			packageColorHex,
 		});
 	}
 

--- a/src/andean/app/use_cases/cart_shop/GetCartByCustomerUseCase.ts
+++ b/src/andean/app/use_cases/cart_shop/GetCartByCustomerUseCase.ts
@@ -23,6 +23,7 @@ import { BoxCartAvailabilityService } from '../../../infra/services/cart/BoxCart
 import { TextileProductAttributesAssembler } from '../../../infra/services/textileProducts/TextileProductAttributesAssembler';
 import { CartColorOptionResponse } from '../../models/cart/CartColorOptionResponse';
 import { TextileProductRepository } from '../../datastore/textileProducts/TextileProduct.repo';
+import { SuperfoodCartSizeResolver } from '../../../infra/services/cart/SuperfoodCartSizeResolver';
 
 @Injectable()
 export class GetCartByCustomerUseCase {
@@ -42,6 +43,7 @@ export class GetCartByCustomerUseCase {
 		private readonly textileProductAttributesAssembler: TextileProductAttributesAssembler,
 		@Inject(TextileProductRepository)
 		private readonly textileProductRepository: TextileProductRepository,
+		private readonly superfoodCartSizeResolver: SuperfoodCartSizeResolver,
 	) {}
 
 	async handle(
@@ -190,12 +192,16 @@ export class GetCartByCustomerUseCase {
 			}
 		}
 
+		const displayCombination =
+			await this.superfoodCartSizeResolver.toDisplayCombination(variant);
+
 		return ShoppingCartItemMapper.toResponse(
 			item,
 			variant,
 			productInfo,
 			ownerName,
 			colorOption,
+			displayCombination,
 		);
 	}
 }

--- a/src/andean/app/use_cases/cart_shop/GetCartByCustomerUseCase.ts
+++ b/src/andean/app/use_cases/cart_shop/GetCartByCustomerUseCase.ts
@@ -192,8 +192,8 @@ export class GetCartByCustomerUseCase {
 			}
 		}
 
-		const displayCombination =
-			await this.superfoodCartSizeResolver.toDisplayCombination(variant);
+		const { displayCombination, packageColorHex } =
+			await this.superfoodCartSizeResolver.enrich(variant);
 
 		return ShoppingCartItemMapper.toResponse(
 			item,
@@ -202,6 +202,7 @@ export class GetCartByCustomerUseCase {
 			ownerName,
 			colorOption,
 			displayCombination,
+			packageColorHex,
 		);
 	}
 }

--- a/src/andean/app/use_cases/superfoods/GetByIdSuperfoodProductDetailUseCase.spec.ts
+++ b/src/andean/app/use_cases/superfoods/GetByIdSuperfoodProductDetailUseCase.spec.ts
@@ -30,6 +30,7 @@ describe('GetByIdSuperfoodProductDetailUseCase - userVote mapping', () => {
 			{} as any, // mediaItemRepository
 			{} as any, // detailSourceProductRepository
 			{ getByProductId: jest.fn().mockResolvedValue([]) } as any, // variantRepository
+			{ getByIds: jest.fn().mockResolvedValue([]) } as any, // sizeOptionAlternativeRepository
 			{} as any, // mediaUrlResolver
 			{} as any, // ownerInfoResolver
 			{} as any, // superfoodProductListColorResolver
@@ -68,9 +69,11 @@ describe('GetByIdSuperfoodProductDetailUseCase - userVote mapping', () => {
 			(useCase as any).superfoodProductRepository = {
 				getSuperfoodProductById: jest.fn().mockResolvedValue({
 					id: 'product-1',
+					status: 'PUBLISHED',
 					baseInfo: { productMedia: {}, nutritional_features: [], benefits: [] },
 					priceInventory: { basePrice: 10, totalStock: 100 },
 					isDiscountActive: false,
+					options: [],
 				}),
 			};
 			(useCase as any).superfoodBenefitRepository = {
@@ -111,9 +114,11 @@ describe('GetByIdSuperfoodProductDetailUseCase - userVote mapping', () => {
 			(useCase as any).superfoodProductRepository = {
 				getSuperfoodProductById: jest.fn().mockResolvedValue({
 					id: 'product-1',
+					status: 'PUBLISHED',
 					baseInfo: { productMedia: {}, nutritional_features: [], benefits: [] },
 					priceInventory: { basePrice: 10, totalStock: 100 },
 					isDiscountActive: false,
+					options: [],
 				}),
 				getAllWithFilters: jest.fn().mockResolvedValue({ products: [] }),
 			};
@@ -152,9 +157,11 @@ describe('GetByIdSuperfoodProductDetailUseCase - userVote mapping', () => {
 			(useCase as any).superfoodProductRepository = {
 				getSuperfoodProductById: jest.fn().mockResolvedValue({
 					id: 'product-1',
+					status: 'PUBLISHED',
 					baseInfo: { productMedia: {}, nutritional_features: [], benefits: [] },
 					priceInventory: { basePrice: 10, totalStock: 100 },
 					isDiscountActive: false,
+					options: [],
 				}),
 				getAllWithFilters: jest.fn().mockResolvedValue({ products: [] }),
 			};
@@ -193,9 +200,11 @@ describe('GetByIdSuperfoodProductDetailUseCase - userVote mapping', () => {
 			(useCase as any).superfoodProductRepository = {
 				getSuperfoodProductById: jest.fn().mockResolvedValue({
 					id: 'product-1',
+					status: 'PUBLISHED',
 					baseInfo: { productMedia: {}, nutritional_features: [], benefits: [] },
 					priceInventory: { basePrice: 10, totalStock: 100 },
 					isDiscountActive: false,
+					options: [],
 				}),
 				getAllWithFilters: jest.fn().mockResolvedValue({ products: [] }),
 			};
@@ -225,6 +234,98 @@ describe('GetByIdSuperfoodProductDetailUseCase - userVote mapping', () => {
 			const result = await useCase.handle('product-1', 'user-456');
 
 			expect(result.reviews.comments[0].userVote).toBe(null);
+		});
+	});
+
+	describe('hero variants mapping', () => {
+		function mockCommonDeps() {
+			(useCase as any).superfoodBenefitRepository = {
+				getByIds: jest.fn().mockResolvedValue([]),
+			};
+			(useCase as any).superfoodNutritionalFeatureRepository = {
+				getByIds: jest.fn().mockResolvedValue([]),
+			};
+			(useCase as any).mediaItemRepository = {
+				getByIds: jest.fn().mockResolvedValue([]),
+			};
+			(useCase as any).mediaUrlResolver = {
+				resolveUrls: jest.fn().mockResolvedValue(new Map()),
+			};
+			(useCase as any).ownerInfoResolver = {
+				resolveDetailed: jest.fn().mockResolvedValue(undefined),
+			};
+			(useCase as any).superfoodProductListColorResolver = {
+				resolveById: jest.fn().mockResolvedValue(undefined),
+				attachCatalogColorFromAggregate: jest.fn().mockResolvedValue([]),
+			};
+			(useCase as any).superfoodProductListMediaResolver = {
+				attachListMediaFromAggregate: jest.fn().mockResolvedValue([]),
+			};
+			(useCase as any).reviewRepository.getByProductIdAndType.mockResolvedValue(
+				[],
+			);
+		}
+
+		it('joins Variant entities with SIZE option labels', async () => {
+			mockCommonDeps();
+			(useCase as any).superfoodProductRepository = {
+				getSuperfoodProductById: jest.fn().mockResolvedValue({
+					id: 'product-1',
+					status: 'PUBLISHED',
+					baseInfo: { productMedia: {}, nutritional_features: [], benefits: [] },
+					priceInventory: { basePrice: 10, totalStock: 100 },
+					isDiscountActive: false,
+					options: [
+						{
+							name: 'SIZE',
+							values: [
+								{ label: '500 g', idOptionAlternative: 'alt-500' },
+								{ label: '1 kg', idOptionAlternative: 'alt-1kg' },
+							],
+						},
+					],
+				}),
+				getAllWithFilters: jest.fn().mockResolvedValue({ products: [] }),
+			};
+			(useCase as any).variantRepository = {
+				getByProductId: jest.fn().mockResolvedValue([
+					{
+						id: 'var-500',
+						productType: ProductType.SUPERFOOD,
+						combination: { SIZE: 'alt-500' },
+						price: 30,
+						stock: 8,
+						sku: 'SKU-500',
+					},
+					{
+						id: 'var-1kg',
+						productType: ProductType.SUPERFOOD,
+						combination: { SIZE: 'alt-1kg' },
+						price: 50,
+						stock: 3,
+						sku: 'SKU-1KG',
+					},
+				]),
+			};
+
+			const result = await useCase.handle('product-1');
+
+			expect(result.variants).toEqual([
+				{
+					variantId: 'var-500',
+					label: '500 g',
+					price: 30,
+					stock: 8,
+					sku: 'SKU-500',
+				},
+				{
+					variantId: 'var-1kg',
+					label: '1 kg',
+					price: 50,
+					stock: 3,
+					sku: 'SKU-1KG',
+				},
+			]);
 		});
 	});
 });

--- a/src/andean/app/use_cases/superfoods/GetByIdSuperfoodProductDetailUseCase.ts
+++ b/src/andean/app/use_cases/superfoods/GetByIdSuperfoodProductDetailUseCase.ts
@@ -10,16 +10,20 @@ import { CommunityRepository } from '../../datastore/community/community.repo';
 import { MediaItemRepository } from '../../datastore/MediaItem.repo';
 import { DetailSourceProductRepository } from '../../datastore/DetailSourceProduct.repo';
 import { VariantRepository } from '../../datastore/Variant.repo';
+import { SuperfoodSizeOptionAlternativeRepository } from '../../datastore/superfoods/SuperfoodSizeOptionAlternative.repo';
 import { ProductType } from '../../../domain/enums/ProductType';
+import { SuperfoodOptionName } from '../../../domain/enums/SuperfoodOptionName';
 import { collectSuperfoodProductMediaIds } from '../../../domain/superfoods/collectSuperfoodProductMediaIds';
 import { Review } from '../../../domain/entities/Review';
 import { MediaItem } from '../../../domain/entities/MediaItem';
+import { Variant } from '../../../domain/entities/Variant';
 import { SuperfoodProduct } from '../../../domain/entities/superfoods/SuperfoodProduct';
 import {
 	SuperfoodProductDetailResponse,
 	MediaImageResponse,
 	ReviewsResponse,
 	SuperfoodProductListItemCompact,
+	SuperfoodDetailVariantResponse,
 } from '../../models/superfoods/SuperfoodProductDetailResponse';
 import type { ProductTraceabilityResponse } from '../../models/shared/ProductTraceabilityResponse';
 import { SuperfoodProductListItem } from '../../models/superfoods/SuperfoodProductListItem';
@@ -55,6 +59,8 @@ export class GetByIdSuperfoodProductDetailUseCase {
 		private readonly detailSourceProductRepository: DetailSourceProductRepository,
 		@Inject(VariantRepository)
 		private readonly variantRepository: VariantRepository,
+		@Inject(SuperfoodSizeOptionAlternativeRepository)
+		private readonly sizeOptionAlternativeRepository: SuperfoodSizeOptionAlternativeRepository,
 		private readonly mediaUrlResolver: MediaUrlResolver,
 		private readonly ownerInfoResolver: OwnerInfoResolver,
 		private readonly superfoodProductListColorResolver: SuperfoodProductListColorResolver,
@@ -105,8 +111,11 @@ export class GetByIdSuperfoodProductDetailUseCase {
 				this.variantRepository.getByProductId(productId),
 			]);
 
-		// 3. Resolver imágenes por IDs en productMedia
-		const images = await this.resolveProductImages(product, mediaItems);
+		// 3. Resolver imágenes y variantes SIZE del hero en paralelo
+		const [images, heroVariants] = await Promise.all([
+			this.resolveProductImages(product, mediaItems),
+			this.buildHeroVariants(product, variants),
+		]);
 
 		// 4. Resolver owner, reviews y color de catálogo en paralelo
 		const [ownerInfo, reviewsResponse, catalogColor] = await Promise.all([
@@ -208,7 +217,7 @@ export class GetByIdSuperfoodProductDetailUseCase {
 					.filter(Boolean)
 					.slice(0, 3),
 				...(() => {
-					const fromVariant = variants
+					const fromVariant = heroVariants
 						.map((v) => v.sku?.trim())
 						.find((s): s is string => Boolean(s));
 					const fromInventory = product.priceInventory.SKU?.trim();
@@ -231,10 +240,68 @@ export class GetByIdSuperfoodProductDetailUseCase {
 				) as ProductTraceabilityResponse,
 			}),
 			isDiscountActive: product.isDiscountActive,
+			variants: heroVariants,
 		};
 	}
 
 	// ── Private helpers ──────────────────────────────────────────────────
+
+	private async buildHeroVariants(
+		product: SuperfoodProduct,
+		variants: Variant[],
+	): Promise<SuperfoodDetailVariantResponse[]> {
+		const superfoodVariants = variants.filter(
+			(variant) => variant.productType === ProductType.SUPERFOOD,
+		);
+		if (!superfoodVariants.length) return [];
+
+		const sizeValues =
+			product.options?.find((option) => option.name === SuperfoodOptionName.SIZE)
+				?.values ?? [];
+		const labelByAlternativeId = new Map<string, string>();
+		for (const value of sizeValues) {
+			const alternativeId = value.idOptionAlternative?.trim();
+			const label = value.label?.trim();
+			if (alternativeId && label) {
+				labelByAlternativeId.set(alternativeId, label);
+			}
+		}
+
+		const missingIds = Array.from(
+			new Set(
+				superfoodVariants
+					.map((variant) => variant.combination?.SIZE?.trim())
+					.filter(
+						(id): id is string =>
+							Boolean(id) && !labelByAlternativeId.has(id),
+					),
+			),
+		);
+
+		if (missingIds.length) {
+			const alternatives =
+				await this.sizeOptionAlternativeRepository.getByIds(missingIds);
+			for (const alternative of alternatives) {
+				const label = alternative.nameLabel?.trim();
+				if (label) labelByAlternativeId.set(alternative.id, label);
+			}
+		}
+
+		return superfoodVariants.map((variant) => {
+			const sizeId = variant.combination?.SIZE?.trim();
+			const label =
+				(sizeId ? labelByAlternativeId.get(sizeId) : undefined) ||
+				(sizeId ? `Size ${sizeId}` : 'Variant');
+			const sku = variant.sku?.trim();
+			return {
+				variantId: variant.id,
+				label,
+				price: variant.price,
+				stock: variant.stock,
+				...(sku ? { sku } : {}),
+			};
+		});
+	}
 
 	private async resolveProductImages(
 		product: SuperfoodProduct,

--- a/src/andean/cartShop.module.ts
+++ b/src/andean/cartShop.module.ts
@@ -30,6 +30,7 @@ import { ProductInfoProviderRegistry } from './infra/services/products/ProductIn
 import { OwnerNameResolver } from './infra/services/OwnerNameResolver';
 import { BoxCartContentResolver } from './infra/services/cart/BoxCartContentResolver';
 import { BoxCartAvailabilityService } from './infra/services/cart/BoxCartAvailabilityService';
+import { SuperfoodCartSizeResolver } from './infra/services/cart/SuperfoodCartSizeResolver';
 import { BoxModule } from './box.module';
 
 @Module({
@@ -81,6 +82,7 @@ import { BoxModule } from './box.module';
 		OwnerNameResolver,
 		BoxCartContentResolver,
 		BoxCartAvailabilityService,
+		SuperfoodCartSizeResolver,
 	],
 	exports: [CartShopRepository, CartShopItemRepository],
 })

--- a/src/andean/infra/controllers/box/box.controller.ts
+++ b/src/andean/infra/controllers/box/box.controller.ts
@@ -53,6 +53,7 @@ import { UpdateEntityStatusDto } from '../dto/UpdateEntityStatusDto';
 import { UpdateBoxUseCase } from '../../../app/use_cases/boxes/UpdateBoxUseCase';
 import { DeleteBoxUseCase } from '../../../app/use_cases/boxes/DeleteBoxUseCase';
 import { GetBoxForAdminEditUseCase } from '../../../app/use_cases/boxes/GetBoxForAdminEditUseCase';
+import { BoxAdminEditResponse } from '../../../app/models/box/BoxAdminEditResponse';
 
 @Controller('boxes')
 export class BoxController {
@@ -265,12 +266,14 @@ export class BoxController {
 	@ApiOperation({
 		summary: 'Obtener box para edición (admin)',
 		description:
-			'Devuelve el agregado persistido (misma forma que creación) para poblar el formulario.',
+			'Devuelve el agregado persistido más las 3 líneas hidratadas (producto, variantes y media) para poblar el formulario sin recorrer el catálogo.',
 	})
 	@ApiParam({ name: 'boxId', description: 'ID del box' })
-	@ApiResponse({ status: 200, type: Box })
+	@ApiResponse({ status: 200, type: BoxAdminEditResponse })
 	@ApiResponse({ status: 404, description: 'Box no encontrado' })
-	async getBoxForAdminEdit(@Param('boxId') boxId: string): Promise<Box> {
+	async getBoxForAdminEdit(
+		@Param('boxId') boxId: string,
+	): Promise<BoxAdminEditResponse> {
 		return this.getBoxForAdminEditUseCase.handle(boxId);
 	}
 

--- a/src/andean/infra/services/box/BoxProductResolutionService.ts
+++ b/src/andean/infra/services/box/BoxProductResolutionService.ts
@@ -94,18 +94,7 @@ export class BoxProductResolutionService {
 				if (mediaId) allMediaIds.add(mediaId);
 			}
 		}
-		// Media de la variante (picker de color/opción): hace falta para el thumbnail del listado
-		for (const variant of variants) {
-			if (variant.productType !== ProductType.TEXTILE) continue;
-			const textile = textileMap.get(variant.productId);
-			if (!textile) continue;
-			const variantMediaId =
-				this.textileVariantPickerMediaService.resolveVariantMainMediaId(
-					textile,
-					variant,
-				);
-			if (variantMediaId) allMediaIds.add(variantMediaId);
-		}
+		this.collectTextileVariantMediaIds(variants, textileMap, allMediaIds);
 
 		const mediaItems =
 			allMediaIds.size > 0
@@ -173,6 +162,7 @@ export class BoxProductResolutionService {
 			if (textile.baseInfo?.mediaIds?.length)
 				allMediaIds.add(textile.baseInfo.mediaIds[0]);
 		}
+		this.collectTextileVariantMediaIds(variants, textileMap, allMediaIds);
 
 		const mediaItems =
 			allMediaIds.size > 0
@@ -236,6 +226,51 @@ export class BoxProductResolutionService {
 			return product.boxPrice;
 		}
 		return catalogPrice;
+	}
+
+	private collectTextileVariantMediaIds(
+		variants: Variant[],
+		textileMap: Map<string, TextileProduct>,
+		allMediaIds: Set<string>,
+	): void {
+		for (const variant of variants) {
+			if (variant.productType !== ProductType.TEXTILE) continue;
+			const textile = textileMap.get(variant.productId);
+			if (!textile) continue;
+			const variantMediaId =
+				this.textileVariantPickerMediaService.resolveVariantMainMediaId(
+					textile,
+					variant,
+				);
+			if (variantMediaId) allMediaIds.add(variantMediaId);
+		}
+	}
+
+	resolveContainedProductThumbnail(
+		variant: Variant,
+		textileMap: Map<string, TextileProduct>,
+		superfoodMap: Map<string, SuperfoodProduct>,
+		mediaMap: Map<string, MediaItem>,
+	): BoxImageResponse {
+		if (variant.productType === ProductType.TEXTILE) {
+			const textile = textileMap.get(variant.productId);
+			const mediaId =
+				(textile
+					? this.textileVariantPickerMediaService.resolveVariantMainMediaId(
+							textile,
+							variant,
+						)
+					: null) || textile?.baseInfo?.mediaIds?.[0]?.trim();
+			return this.resolveImage(mediaId, mediaMap);
+		}
+		if (variant.productType === ProductType.SUPERFOOD) {
+			const superfood = superfoodMap.get(variant.productId);
+			return this.resolveImage(
+				superfood?.baseInfo?.productMedia?.mainImgId,
+				mediaMap,
+			);
+		}
+		return { url: '', name: '' };
 	}
 
 	resolveListProductThumbnailUrl(

--- a/src/andean/infra/services/cart/ShoppingCartItemMapper.ts
+++ b/src/andean/infra/services/cart/ShoppingCartItemMapper.ts
@@ -26,6 +26,7 @@ export class ShoppingCartItemMapper {
 		ownerName: string,
 		colorOption?: CartColorOptionResponse | null,
 		displayCombination?: Record<string, string>,
+		packageColorHex?: string,
 	): ShoppingCartItemResponse {
 		return {
 			productId: item.productId,
@@ -41,6 +42,7 @@ export class ShoppingCartItemMapper {
 			maxStock: variant?.stock || 0,
 			isDiscountActive: productInfo.isDiscountActive,
 			productType: item.productType,
+			...(packageColorHex ? { packageColorHex } : {}),
 		};
 	}
 
@@ -85,6 +87,7 @@ export class ShoppingCartItemMapper {
 		quantity: number;
 		colorOption?: CartColorOptionResponse | null;
 		displayCombination?: Record<string, string>;
+		packageColorHex?: string;
 	}): ShoppingCartItemResponse {
 		return {
 			productId: params.variant.productId,
@@ -100,6 +103,9 @@ export class ShoppingCartItemMapper {
 			maxStock: params.variant.stock,
 			isDiscountActive: params.productInfo.isDiscountActive,
 			productType: params.variant.productType,
+			...(params.packageColorHex
+				? { packageColorHex: params.packageColorHex }
+				: {}),
 		};
 	}
 }

--- a/src/andean/infra/services/cart/ShoppingCartItemMapper.ts
+++ b/src/andean/infra/services/cart/ShoppingCartItemMapper.ts
@@ -25,13 +25,14 @@ export class ShoppingCartItemMapper {
 		productInfo: ProductInfo,
 		ownerName: string,
 		colorOption?: CartColorOptionResponse | null,
+		displayCombination?: Record<string, string>,
 	): ShoppingCartItemResponse {
 		return {
 			productId: item.productId,
 			variantId: item.variantProductId ?? null,
 			ownerName,
 			title: productInfo.title,
-			combinationVariant: variant?.combination || {},
+			combinationVariant: displayCombination ?? variant?.combination ?? {},
 			colorOption: colorOption ?? undefined,
 			thumbnailImgUrl: productInfo.thumbnailImgUrl,
 			unitPrice: item.unitPrice,
@@ -83,13 +84,14 @@ export class ShoppingCartItemMapper {
 		ownerName: string;
 		quantity: number;
 		colorOption?: CartColorOptionResponse | null;
+		displayCombination?: Record<string, string>;
 	}): ShoppingCartItemResponse {
 		return {
 			productId: params.variant.productId,
 			variantId: params.variant.id,
 			ownerName: params.ownerName,
 			title: params.productInfo.title,
-			combinationVariant: params.variant.combination,
+			combinationVariant: params.displayCombination ?? params.variant.combination,
 			colorOption: params.colorOption ?? undefined,
 			thumbnailImgUrl: params.productInfo.thumbnailImgUrl,
 			unitPrice: params.variant.price,

--- a/src/andean/infra/services/cart/SuperfoodCartSizeResolver.spec.ts
+++ b/src/andean/infra/services/cart/SuperfoodCartSizeResolver.spec.ts
@@ -9,6 +9,8 @@ import { SuperfoodOptions } from '../../../domain/entities/superfoods/SuperfoodO
 import { SuperfoodOptionsItem } from '../../../domain/entities/superfoods/SuperfoodOptionsItem';
 import { SuperfoodProduct } from '../../../domain/entities/superfoods/SuperfoodProduct';
 import { SizeOptionAlternative } from '../../../domain/entities/superfoods/SizeOptionAlternative';
+import { SuperfoodColorRepository } from '../../../app/datastore/superfoods/SuperfoodColor.repo';
+import { SuperfoodColor } from '../../../domain/entities/superfoods/SuperfoodColor';
 
 const SIZE_ID = '6a7f3b37747108abdddbcd23';
 
@@ -35,6 +37,7 @@ describe('SuperfoodCartSizeResolver', () => {
 	let sizeOptionRepository: jest.Mocked<
 		Pick<SuperfoodSizeOptionAlternativeRepository, 'getByIds'>
 	>;
+	let colorRepository: jest.Mocked<Pick<SuperfoodColorRepository, 'getById'>>;
 
 	beforeEach(async () => {
 		productRepository = {
@@ -42,6 +45,9 @@ describe('SuperfoodCartSizeResolver', () => {
 		};
 		sizeOptionRepository = {
 			getByIds: jest.fn(),
+		};
+		colorRepository = {
+			getById: jest.fn(),
 		};
 
 		const module: TestingModule = await Test.createTestingModule({
@@ -54,6 +60,10 @@ describe('SuperfoodCartSizeResolver', () => {
 				{
 					provide: SuperfoodSizeOptionAlternativeRepository,
 					useValue: sizeOptionRepository,
+				},
+				{
+					provide: SuperfoodColorRepository,
+					useValue: colorRepository,
 				},
 			],
 		}).compile();
@@ -125,5 +135,24 @@ describe('SuperfoodCartSizeResolver', () => {
 		await expect(
 			resolver.toDisplayCombination(superfoodVariant()),
 		).resolves.toEqual({ SIZE: SIZE_ID });
+	});
+
+	it('includes the catalog package color hex', async () => {
+		productRepository.getSuperfoodProductById.mockResolvedValue({
+			colorId: 'color-1',
+			options: [
+				new SuperfoodOptions(SuperfoodOptionName.SIZE, [
+					new SuperfoodOptionsItem('250 g', undefined, SIZE_ID),
+				]),
+			],
+		} as SuperfoodProduct);
+		colorRepository.getById.mockResolvedValue(
+			new SuperfoodColor('color-1', 'Forest', '#0E6851'),
+		);
+
+		await expect(resolver.enrich(superfoodVariant())).resolves.toEqual({
+			displayCombination: { SIZE: '250 g', size: '250 g' },
+			packageColorHex: '#0E6851',
+		});
 	});
 });

--- a/src/andean/infra/services/cart/SuperfoodCartSizeResolver.spec.ts
+++ b/src/andean/infra/services/cart/SuperfoodCartSizeResolver.spec.ts
@@ -1,0 +1,129 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SuperfoodCartSizeResolver } from './SuperfoodCartSizeResolver';
+import { SuperfoodProductRepository } from '../../../app/datastore/superfoods/SuperfoodProduct.repo';
+import { SuperfoodSizeOptionAlternativeRepository } from '../../../app/datastore/superfoods/SuperfoodSizeOptionAlternative.repo';
+import { Variant } from '../../../domain/entities/Variant';
+import { ProductType } from '../../../domain/enums/ProductType';
+import { SuperfoodOptionName } from '../../../domain/enums/SuperfoodOptionName';
+import { SuperfoodOptions } from '../../../domain/entities/superfoods/SuperfoodOptions';
+import { SuperfoodOptionsItem } from '../../../domain/entities/superfoods/SuperfoodOptionsItem';
+import { SuperfoodProduct } from '../../../domain/entities/superfoods/SuperfoodProduct';
+import { SizeOptionAlternative } from '../../../domain/entities/superfoods/SizeOptionAlternative';
+
+const SIZE_ID = '6a7f3b37747108abdddbcd23';
+
+function superfoodVariant(
+	combination: Record<string, string> = { SIZE: SIZE_ID },
+): Variant {
+	return new Variant(
+		'variant-1',
+		'product-1',
+		ProductType.SUPERFOOD,
+		combination,
+		50,
+		10,
+		new Date(),
+		new Date(),
+	);
+}
+
+describe('SuperfoodCartSizeResolver', () => {
+	let resolver: SuperfoodCartSizeResolver;
+	let productRepository: jest.Mocked<
+		Pick<SuperfoodProductRepository, 'getSuperfoodProductById'>
+	>;
+	let sizeOptionRepository: jest.Mocked<
+		Pick<SuperfoodSizeOptionAlternativeRepository, 'getByIds'>
+	>;
+
+	beforeEach(async () => {
+		productRepository = {
+			getSuperfoodProductById: jest.fn(),
+		};
+		sizeOptionRepository = {
+			getByIds: jest.fn(),
+		};
+
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [
+				SuperfoodCartSizeResolver,
+				{
+					provide: SuperfoodProductRepository,
+					useValue: productRepository,
+				},
+				{
+					provide: SuperfoodSizeOptionAlternativeRepository,
+					useValue: sizeOptionRepository,
+				},
+			],
+		}).compile();
+
+		resolver = module.get(SuperfoodCartSizeResolver);
+	});
+
+	it('returns empty combination when variant is null', async () => {
+		await expect(resolver.toDisplayCombination(null)).resolves.toEqual({});
+	});
+
+	it('leaves textile combinations unchanged', async () => {
+		const variant = new Variant(
+			'variant-1',
+			'product-1',
+			ProductType.TEXTILE,
+			{ size: 'M', color: 'gray' },
+			40,
+			5,
+			new Date(),
+			new Date(),
+		);
+
+		await expect(resolver.toDisplayCombination(variant)).resolves.toEqual({
+			size: 'M',
+			color: 'gray',
+		});
+		expect(productRepository.getSuperfoodProductById).not.toHaveBeenCalled();
+	});
+
+	it('replaces SIZE id with the product option label', async () => {
+		productRepository.getSuperfoodProductById.mockResolvedValue({
+			options: [
+				new SuperfoodOptions(SuperfoodOptionName.SIZE, [
+					new SuperfoodOptionsItem('250 g', undefined, SIZE_ID),
+				]),
+			],
+		} as SuperfoodProduct);
+
+		await expect(
+			resolver.toDisplayCombination(superfoodVariant()),
+		).resolves.toEqual({
+			SIZE: '250 g',
+			size: '250 g',
+		});
+		expect(sizeOptionRepository.getByIds).not.toHaveBeenCalled();
+	});
+
+	it('falls back to the size alternative nameLabel', async () => {
+		productRepository.getSuperfoodProductById.mockResolvedValue({
+			options: [],
+		} as SuperfoodProduct);
+		sizeOptionRepository.getByIds.mockResolvedValue([
+			new SizeOptionAlternative(SIZE_ID, '400 g', 400, 'g', 8),
+		]);
+
+		await expect(
+			resolver.toDisplayCombination(superfoodVariant()),
+		).resolves.toEqual({
+			SIZE: '400 g',
+			size: '400 g',
+		});
+	});
+
+	it('keeps the SIZE id when no label can be resolved', async () => {
+		productRepository.getSuperfoodProductById.mockResolvedValue(null);
+		sizeOptionRepository.getByIds.mockResolvedValue([]);
+
+		await expect(
+			resolver.toDisplayCombination(superfoodVariant()),
+		).resolves.toEqual({ SIZE: SIZE_ID });
+	});
+});

--- a/src/andean/infra/services/cart/SuperfoodCartSizeResolver.ts
+++ b/src/andean/infra/services/cart/SuperfoodCartSizeResolver.ts
@@ -1,13 +1,19 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { SuperfoodProductRepository } from '../../../app/datastore/superfoods/SuperfoodProduct.repo';
 import { SuperfoodSizeOptionAlternativeRepository } from '../../../app/datastore/superfoods/SuperfoodSizeOptionAlternative.repo';
+import { SuperfoodColorRepository } from '../../../app/datastore/superfoods/SuperfoodColor.repo';
+import { SuperfoodProduct } from '../../../domain/entities/superfoods/SuperfoodProduct';
 import { Variant } from '../../../domain/entities/Variant';
 import { ProductType } from '../../../domain/enums/ProductType';
 import { SuperfoodOptionName } from '../../../domain/enums/SuperfoodOptionName';
 
+export type SuperfoodCartDisplay = {
+	displayCombination: Record<string, string>;
+	packageColorHex?: string;
+};
+
 /**
- * Reemplaza el ObjectId de combination.SIZE por la etiqueta humana
- * (p. ej. "250 g") para que el carrito no muestre IDs de Mongo.
+ * Enriquece items de superfood en el carrito: etiqueta SIZE humana y hex de fondo.
  */
 @Injectable()
 export class SuperfoodCartSizeResolver {
@@ -16,35 +22,52 @@ export class SuperfoodCartSizeResolver {
 		private readonly superfoodProductRepository: SuperfoodProductRepository,
 		@Inject(SuperfoodSizeOptionAlternativeRepository)
 		private readonly sizeOptionAlternativeRepository: SuperfoodSizeOptionAlternativeRepository,
+		@Inject(SuperfoodColorRepository)
+		private readonly superfoodColorRepository: SuperfoodColorRepository,
 	) {}
+
+	async enrich(variant: Variant | null): Promise<SuperfoodCartDisplay> {
+		const combination = { ...(variant?.combination || {}) };
+		if (!variant || variant.productType !== ProductType.SUPERFOOD) {
+			return { displayCombination: combination };
+		}
+
+		const product =
+			await this.superfoodProductRepository.getSuperfoodProductById(
+				variant.productId,
+			);
+
+		const sizeId = combination.SIZE?.trim();
+		let displayCombination = combination;
+		if (sizeId) {
+			const label = await this.resolveLabel(product, sizeId);
+			if (label) {
+				displayCombination = {
+					...combination,
+					SIZE: label,
+					size: label,
+				};
+			}
+		}
+
+		const packageColorHex = await this.resolvePackageColorHex(product);
+		return {
+			displayCombination,
+			...(packageColorHex ? { packageColorHex } : {}),
+		};
+	}
 
 	async toDisplayCombination(
 		variant: Variant | null,
 	): Promise<Record<string, string>> {
-		const combination = { ...(variant?.combination || {}) };
-		if (!variant || variant.productType !== ProductType.SUPERFOOD) {
-			return combination;
-		}
-
-		const sizeId = combination.SIZE?.trim();
-		if (!sizeId) return combination;
-
-		const label = await this.resolveLabel(variant.productId, sizeId);
-		if (!label) return combination;
-
-		return {
-			...combination,
-			SIZE: label,
-			size: label,
-		};
+		const { displayCombination } = await this.enrich(variant);
+		return displayCombination;
 	}
 
 	private async resolveLabel(
-		productId: string,
+		product: SuperfoodProduct | null,
 		sizeId: string,
 	): Promise<string | null> {
-		const product =
-			await this.superfoodProductRepository.getSuperfoodProductById(productId);
 		const fromOptions = product?.options
 			?.find((option) => option.name === SuperfoodOptionName.SIZE)
 			?.values?.find((value) => value.idOptionAlternative?.trim() === sizeId)
@@ -54,5 +77,15 @@ export class SuperfoodCartSizeResolver {
 		const [alternative] =
 			await this.sizeOptionAlternativeRepository.getByIds([sizeId]);
 		return alternative?.nameLabel?.trim() || null;
+	}
+
+	private async resolvePackageColorHex(
+		product: SuperfoodProduct | null,
+	): Promise<string | undefined> {
+		const colorId = product?.colorId?.trim();
+		if (!colorId) return undefined;
+		const color = await this.superfoodColorRepository.getById(colorId);
+		const hex = color?.hexCodeColor?.trim();
+		return hex || undefined;
 	}
 }

--- a/src/andean/infra/services/cart/SuperfoodCartSizeResolver.ts
+++ b/src/andean/infra/services/cart/SuperfoodCartSizeResolver.ts
@@ -1,0 +1,58 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { SuperfoodProductRepository } from '../../../app/datastore/superfoods/SuperfoodProduct.repo';
+import { SuperfoodSizeOptionAlternativeRepository } from '../../../app/datastore/superfoods/SuperfoodSizeOptionAlternative.repo';
+import { Variant } from '../../../domain/entities/Variant';
+import { ProductType } from '../../../domain/enums/ProductType';
+import { SuperfoodOptionName } from '../../../domain/enums/SuperfoodOptionName';
+
+/**
+ * Reemplaza el ObjectId de combination.SIZE por la etiqueta humana
+ * (p. ej. "250 g") para que el carrito no muestre IDs de Mongo.
+ */
+@Injectable()
+export class SuperfoodCartSizeResolver {
+	constructor(
+		@Inject(SuperfoodProductRepository)
+		private readonly superfoodProductRepository: SuperfoodProductRepository,
+		@Inject(SuperfoodSizeOptionAlternativeRepository)
+		private readonly sizeOptionAlternativeRepository: SuperfoodSizeOptionAlternativeRepository,
+	) {}
+
+	async toDisplayCombination(
+		variant: Variant | null,
+	): Promise<Record<string, string>> {
+		const combination = { ...(variant?.combination || {}) };
+		if (!variant || variant.productType !== ProductType.SUPERFOOD) {
+			return combination;
+		}
+
+		const sizeId = combination.SIZE?.trim();
+		if (!sizeId) return combination;
+
+		const label = await this.resolveLabel(variant.productId, sizeId);
+		if (!label) return combination;
+
+		return {
+			...combination,
+			SIZE: label,
+			size: label,
+		};
+	}
+
+	private async resolveLabel(
+		productId: string,
+		sizeId: string,
+	): Promise<string | null> {
+		const product =
+			await this.superfoodProductRepository.getSuperfoodProductById(productId);
+		const fromOptions = product?.options
+			?.find((option) => option.name === SuperfoodOptionName.SIZE)
+			?.values?.find((value) => value.idOptionAlternative?.trim() === sizeId)
+			?.label?.trim();
+		if (fromOptions) return fromOptions;
+
+		const [alternative] =
+			await this.sizeOptionAlternativeRepository.getByIds([sizeId]);
+		return alternative?.nameLabel?.trim() || null;
+	}
+}

--- a/test/catalog-published-filter.e2e-spec.ts
+++ b/test/catalog-published-filter.e2e-spec.ts
@@ -146,6 +146,7 @@ describe('GetBoxDetailUseCase — public catalog', () => {
 			{ resolveDetailed: jest.fn() } as never,
 			{ buildForProducts: jest.fn() } as never,
 			{ getById: jest.fn() } as never,
+			{ getByIds: jest.fn() } as never,
 		);
 
 		await expect(useCase.handle('box-1')).rejects.toThrow(NotFoundException);

--- a/test/catalog-published-filter.e2e-spec.ts
+++ b/test/catalog-published-filter.e2e-spec.ts
@@ -145,6 +145,7 @@ describe('GetBoxDetailUseCase — public catalog', () => {
 			{ bulkFetchBoxDependencies: jest.fn() } as never,
 			{ resolveDetailed: jest.fn() } as never,
 			{ buildForProducts: jest.fn() } as never,
+			{ getById: jest.fn() } as never,
 		);
 
 		await expect(useCase.handle('box-1')).rejects.toThrow(NotFoundException);

--- a/test/fixtures/superfood-product.fixture.json
+++ b/test/fixtures/superfood-product.fixture.json
@@ -356,6 +356,15 @@
 				"averagePunctuation": 0
 			},
 			"comments": []
-		}
+		},
+		"variants": [
+			{
+				"variantId": "variant-uuid-123",
+				"label": "500 g",
+				"price": 25.5,
+				"stock": 100,
+				"sku": "QUINUA-PREM-001-500G"
+			}
+		]
 	}
 }


### PR DESCRIPTION
## Summary
- Expose SIZE variants on public superfood product detail for the PDP.
- Resolve SIZE option ids to human labels and include catalog package color on cart responses.
- Return hydrated `slots` on admin box edit so the frontend stops scanning the full catalog.
- Resolve superfood pack size on public box detail and box list; use textile variant media for Look Inside thumbnails.
